### PR TITLE
Add MySQL setup and manager registration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,5 +64,10 @@
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -1,17 +1,80 @@
 package org.maks.mineSystemPlugin;
 
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.managers.PickaxeManager;
+import org.maks.mineSystemPlugin.managers.SphereManager;
+import org.maks.mineSystemPlugin.managers.StaminaManager;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 
 public final class MineSystemPlugin extends JavaPlugin {
 
+    private Connection connection;
+    private StaminaManager staminaManager;
+    private SphereManager sphereManager;
+    private PickaxeManager pickaxeManager;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        saveDefaultConfig();
+        FileConfiguration config = getConfig();
 
+        try {
+            String host = config.getString("mysql.host");
+            int port = config.getInt("mysql.port");
+            String database = config.getString("mysql.database");
+            String username = config.getString("mysql.username");
+            String password = config.getString("mysql.password");
+            String url = "jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=false&autoReconnect=true";
+
+            connection = DriverManager.getConnection(url, username, password);
+
+            staminaManager = new StaminaManager(this);
+            sphereManager = new SphereManager(this);
+            pickaxeManager = new PickaxeManager(this);
+        } catch (SQLException e) {
+            getLogger().severe("Failed to connect to MySQL: " + e.getMessage());
+            getServer().getPluginManager().disablePlugin(this);
+        }
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (staminaManager != null) {
+            staminaManager.saveAll();
+        }
+        if (sphereManager != null) {
+            sphereManager.saveAll();
+        }
+        if (pickaxeManager != null) {
+            pickaxeManager.saveAll();
+        }
+
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                getLogger().severe("Failed to close MySQL connection: " + e.getMessage());
+            }
+        }
+    }
+
+    public Connection getConnection() {
+        return connection;
+    }
+
+    public StaminaManager getStaminaManager() {
+        return staminaManager;
+    }
+
+    public SphereManager getSphereManager() {
+        return sphereManager;
+    }
+
+    public PickaxeManager getPickaxeManager() {
+        return pickaxeManager;
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/managers/PickaxeManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/managers/PickaxeManager.java
@@ -1,0 +1,20 @@
+package org.maks.mineSystemPlugin.managers;
+
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+/**
+ * Handles pickaxe related logic.
+ */
+public class PickaxeManager {
+    private final MineSystemPlugin plugin;
+
+    public PickaxeManager(MineSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Persist all pickaxe data to storage.
+     */
+    public void saveAll() {
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/managers/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/managers/SphereManager.java
@@ -1,0 +1,20 @@
+package org.maks.mineSystemPlugin.managers;
+
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+/**
+ * Handles sphere related logic.
+ */
+public class SphereManager {
+    private final MineSystemPlugin plugin;
+
+    public SphereManager(MineSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Persist all sphere data to storage.
+     */
+    public void saveAll() {
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/managers/StaminaManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/managers/StaminaManager.java
@@ -1,0 +1,20 @@
+package org.maks.mineSystemPlugin.managers;
+
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+/**
+ * Handles player stamina data.
+ */
+public class StaminaManager {
+    private final MineSystemPlugin plugin;
+
+    public StaminaManager(MineSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Persist all stamina data to storage.
+     */
+    public void saveAll() {
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+mysql:
+  host: localhost
+  port: 3306
+  database: minesystem
+  username: root
+  password: password

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,4 +1,5 @@
-name: mineSystemPlugin
+name: MineSystemPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.mineSystemPlugin.MineSystemPlugin
 api-version: '1.20'
+author: maks


### PR DESCRIPTION
## Summary
- Load config and connect to MySQL on startup
- Register Stamina, Sphere, and Pickaxe managers
- Save data and close database connection on shutdown
- Add MySQL dependency and default configuration

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc5850c0832aaf6e8a2971ea0f84