### PR TITLE
Add async SQLite DAOs for gameplay data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.44.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -1,17 +1,49 @@
 package org.maks.mineSystemPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+import org.maks.mineSystemPlugin.database.dao.PickaxesDao;
+import org.maks.mineSystemPlugin.database.dao.PlayersDao;
+import org.maks.mineSystemPlugin.database.dao.QuestsDao;
+import org.maks.mineSystemPlugin.database.dao.SpheresDao;
 
 public final class MineSystemPlugin extends JavaPlugin {
+    private DatabaseManager database;
+    private PlayersDao playersDao;
+    private PickaxesDao pickaxesDao;
+    private QuestsDao questsDao;
+    private SpheresDao spheresDao;
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
-
+        database = new DatabaseManager(this);
+        playersDao = new PlayersDao(database);
+        pickaxesDao = new PickaxesDao(database);
+        questsDao = new QuestsDao(database);
+        spheresDao = new SpheresDao(database);
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (database != null) {
+            database.close();
+        }
+    }
+
+    public PlayersDao getPlayersDao() {
+        return playersDao;
+    }
+
+    public PickaxesDao getPickaxesDao() {
+        return pickaxesDao;
+    }
+
+    public QuestsDao getQuestsDao() {
+        return questsDao;
+    }
+
+    public SpheresDao getSpheresDao() {
+        return spheresDao;
     }
 }
+

--- a/src/main/java/org/maks/mineSystemPlugin/database/DatabaseManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/database/DatabaseManager.java
@@ -1,0 +1,57 @@
+package org.maks.mineSystemPlugin.database;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class DatabaseManager {
+    private final HikariDataSource dataSource;
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
+
+    public DatabaseManager(JavaPlugin plugin) {
+        File dataFolder = plugin.getDataFolder();
+        if (!dataFolder.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            dataFolder.mkdirs();
+        }
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:sqlite:" + new File(dataFolder, "data.db"));
+        config.setConnectionTestQuery("SELECT 1");
+        config.setMaximumPoolSize(10);
+        this.dataSource = new HikariDataSource(config);
+        initTables();
+    }
+
+    private void initTables() {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS players (uuid TEXT PRIMARY KEY, stamina INTEGER, reset_timestamp INTEGER)");
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS pickaxes (uuid TEXT PRIMARY KEY, material TEXT, durability INTEGER, enchants TEXT)");
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS quests (uuid TEXT PRIMARY KEY, progress INTEGER)");
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS spheres (uuid TEXT PRIMARY KEY, type TEXT, start_time INTEGER)");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public HikariDataSource getDataSource() {
+        return dataSource;
+    }
+
+    public ExecutorService getExecutor() {
+        return executor;
+    }
+
+    public void close() {
+        dataSource.close();
+        executor.shutdownNow();
+    }
+}
+

--- a/src/main/java/org/maks/mineSystemPlugin/database/dao/PickaxesDao.java
+++ b/src/main/java/org/maks/mineSystemPlugin/database/dao/PickaxesDao.java
@@ -1,0 +1,56 @@
+package org.maks.mineSystemPlugin.database.dao;
+
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class PickaxesDao {
+    private final DatabaseManager database;
+
+    public PickaxesDao(DatabaseManager database) {
+        this.database = database;
+    }
+
+    public CompletableFuture<PickaxeData> get(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT material, durability, enchants FROM pickaxes WHERE uuid=?";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, uuid.toString());
+                ResultSet rs = ps.executeQuery();
+                if (rs.next()) {
+                    return new PickaxeData(uuid, rs.getString("material"), rs.getInt("durability"), rs.getString("enchants"));
+                }
+                return null;
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, database.getExecutor());
+    }
+
+    public CompletableFuture<Void> save(PickaxeData data) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO pickaxes(uuid, material, durability, enchants) VALUES(?,?,?,?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET material=excluded.material, durability=excluded.durability, enchants=excluded.enchants";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, data.uuid().toString());
+                ps.setString(2, data.material());
+                ps.setInt(3, data.durability());
+                ps.setString(4, data.enchants());
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, database.getExecutor());
+    }
+
+    public record PickaxeData(UUID uuid, String material, int durability, String enchants) {}
+}
+

--- a/src/main/java/org/maks/mineSystemPlugin/database/dao/PlayersDao.java
+++ b/src/main/java/org/maks/mineSystemPlugin/database/dao/PlayersDao.java
@@ -1,0 +1,55 @@
+package org.maks.mineSystemPlugin.database.dao;
+
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class PlayersDao {
+    private final DatabaseManager database;
+
+    public PlayersDao(DatabaseManager database) {
+        this.database = database;
+    }
+
+    public CompletableFuture<PlayerData> get(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT stamina, reset_timestamp FROM players WHERE uuid=?";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, uuid.toString());
+                ResultSet rs = ps.executeQuery();
+                if (rs.next()) {
+                    return new PlayerData(uuid, rs.getInt("stamina"), rs.getLong("reset_timestamp"));
+                }
+                return null;
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, database.getExecutor());
+    }
+
+    public CompletableFuture<Void> save(PlayerData data) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO players(uuid, stamina, reset_timestamp) VALUES(?,?,?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET stamina=excluded.stamina, reset_timestamp=excluded.reset_timestamp";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, data.uuid().toString());
+                ps.setInt(2, data.stamina());
+                ps.setLong(3, data.resetTimestamp());
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, database.getExecutor());
+    }
+
+    public record PlayerData(UUID uuid, int stamina, long resetTimestamp) {}
+}
+

--- a/src/main/java/org/maks/mineSystemPlugin/database/dao/QuestsDao.java
+++ b/src/main/java/org/maks/mineSystemPlugin/database/dao/QuestsDao.java
@@ -1,0 +1,54 @@
+package org.maks.mineSystemPlugin.database.dao;
+
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class QuestsDao {
+    private final DatabaseManager database;
+
+    public QuestsDao(DatabaseManager database) {
+        this.database = database;
+    }
+
+    public CompletableFuture<QuestData> get(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT progress FROM quests WHERE uuid=?";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, uuid.toString());
+                ResultSet rs = ps.executeQuery();
+                if (rs.next()) {
+                    return new QuestData(uuid, rs.getInt("progress"));
+                }
+                return null;
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, database.getExecutor());
+    }
+
+    public CompletableFuture<Void> save(QuestData data) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO quests(uuid, progress) VALUES(?,?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET progress=excluded.progress";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, data.uuid().toString());
+                ps.setInt(2, data.progress());
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, database.getExecutor());
+    }
+
+    public record QuestData(UUID uuid, int progress) {}
+}
+

--- a/src/main/java/org/maks/mineSystemPlugin/database/dao/SpheresDao.java
+++ b/src/main/java/org/maks/mineSystemPlugin/database/dao/SpheresDao.java
@@ -1,0 +1,55 @@
+package org.maks.mineSystemPlugin.database.dao;
+
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class SpheresDao {
+    private final DatabaseManager database;
+
+    public SpheresDao(DatabaseManager database) {
+        this.database = database;
+    }
+
+    public CompletableFuture<SphereData> get(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT type, start_time FROM spheres WHERE uuid=?";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, uuid.toString());
+                ResultSet rs = ps.executeQuery();
+                if (rs.next()) {
+                    return new SphereData(uuid, rs.getString("type"), rs.getLong("start_time"));
+                }
+                return null;
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, database.getExecutor());
+    }
+
+    public CompletableFuture<Void> save(SphereData data) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO spheres(uuid, type, start_time) VALUES(?,?,?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET type=excluded.type, start_time=excluded.start_time";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, data.uuid().toString());
+                ps.setString(2, data.type());
+                ps.setLong(3, data.startTime());
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, database.getExecutor());
+    }
+
+    public record SphereData(UUID uuid, String type, long startTime) {}
+}
+


### PR DESCRIPTION
## Summary
- add SQLite and HikariCP dependencies
- implement `DatabaseManager` to initialize tables and provide async access
- create DAOs for players, pickaxes, quests and spheres
- wire DAOs into main plugin

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc58e128832aa42372a887a1b115