### PR TITLE
Implement stamina manager with timed reset

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -2,11 +2,17 @@ package org.maks.mineSystemPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+/**
+ * Main plugin class which sets up the {@link StaminaManager}.
+ */
 public final class MineSystemPlugin extends JavaPlugin {
+
+    private StaminaManager staminaManager;
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        // Initialize stamina with a default max of 100. This value may grow with quests.
+        staminaManager = new StaminaManager(100);
 
     }
 

--- a/src/main/java/org/maks/mineSystemPlugin/StaminaManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/StaminaManager.java
@@ -1,0 +1,54 @@
+package org.maks.mineSystemPlugin;
+
+public class StaminaManager {
+    private int currentStamina;
+    private int maxStamina;
+    private long firstUsageTimestamp; // millis
+    private static final int ENTRY_COST = 10;
+    private static final long RESET_INTERVAL_MILLIS = 12L * 60 * 60 * 1000; // 12 hours
+
+    public StaminaManager(int maxStamina) {
+        this.maxStamina = maxStamina;
+        this.currentStamina = maxStamina;
+        this.firstUsageTimestamp = 0; // 0 means not used yet after last reset
+    }
+
+    public int getCurrentStamina() {
+        return currentStamina;
+    }
+
+    public int getMaxStamina() {
+        return maxStamina;
+    }
+
+    public void setMaxStamina(int newMax) {
+        this.maxStamina = newMax;
+        if (currentStamina > maxStamina) {
+            currentStamina = maxStamina;
+        }
+    }
+
+    /**
+     * Attempts to enter a sphere. Costs 10 stamina.
+     * Returns true if the player has enough stamina, false otherwise.
+     */
+    public boolean enterSphere() {
+        resetIfNeeded();
+        if (currentStamina < ENTRY_COST) {
+            return false;
+        }
+        if (firstUsageTimestamp == 0) {
+            firstUsageTimestamp = System.currentTimeMillis();
+        }
+        currentStamina -= ENTRY_COST;
+        return true;
+    }
+
+    private void resetIfNeeded() {
+        if (firstUsageTimestamp != 0 &&
+                System.currentTimeMillis() - firstUsageTimestamp >= RESET_INTERVAL_MILLIS) {
+            currentStamina = maxStamina;
+            firstUsageTimestamp = 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add StaminaManager tracking stamina, first usage timestamp, and automatic 12h reset
- initialize StaminaManager in main plugin class

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc59a668832ab2c42af314349f89