### PR TITLE
Implement custom tool durability and enchantments

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -1,13 +1,14 @@
 package org.maks.mineSystemPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.tool.ToolListener;
 
 public final class MineSystemPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
-
+        // Register listeners
+        getServer().getPluginManager().registerEvents(new ToolListener(this), this);
     }
 
     @Override

--- a/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
@@ -1,0 +1,176 @@
+package org.maks.mineSystemPlugin.tool;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Factory and utility methods for custom mining tools.
+ */
+public final class CustomTool {
+
+    private CustomTool() {
+    }
+
+    /**
+     * Creates a new pickaxe of the given material and initial durability.
+     * The second lore line is always formatted as "Durability: X/Y".
+     *
+     * @param plugin      plugin instance for namespaced keys
+     * @param material    tool material type
+     * @param name        display name of the item
+     * @param description first lore line description
+     * @param canDestroy  set of blocks the tool can destroy
+     * @return item stack representing the tool
+     */
+    public static ItemStack createTool(Plugin plugin, ToolMaterial material, String name, String description,
+            Set<Material> canDestroy) {
+        ItemStack stack = new ItemStack(material.getMaterial());
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) {
+            return stack;
+        }
+
+        meta.displayName(Component.text(name));
+
+        // base lore with durability line
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.translateAlternateColorCodes('&', description));
+        lore.add(formatDurability(material.getMaxDurability(), material.getMaxDurability()));
+        meta.setLore(lore);
+
+        // persistence
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        NamespacedKey maxKey = new NamespacedKey(plugin, "max_durability");
+        NamespacedKey curKey = new NamespacedKey(plugin, "durability");
+        pdc.set(maxKey, PersistentDataType.INTEGER, material.getMaxDurability());
+        pdc.set(curKey, PersistentDataType.INTEGER, material.getMaxDurability());
+
+        // allowed blocks restriction
+        if (canDestroy != null && !canDestroy.isEmpty()) {
+            meta.setCanDestroy(new HashSet<>(canDestroy));
+        }
+
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    /**
+     * Adds the vanilla DIG_SPEED enchantment using a custom name "Mining Speed".
+     * A lore line describing the enchantment is inserted after the durability line
+     * (always at index 2). New enchant descriptions are added from the top.
+     */
+    public static void addMiningSpeed(ItemStack item, int level) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+
+        meta.addEnchant(Enchantment.DIG_SPEED, level, true);
+        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+
+        insertLoreLine(meta, ChatColor.AQUA + "Mining Speed " + roman(level));
+        item.setItemMeta(meta);
+    }
+
+    /**
+     * Adds a custom Duplicate enchant. Levels correspond to 3%, 4% and 5% chance
+     * to drop an extra item. Lore line is inserted from the top like other
+     * enchantments.
+     */
+    public static void addDuplicate(Plugin plugin, ItemStack item, int level) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        NamespacedKey dupKey = new NamespacedKey(plugin, "duplicate");
+        pdc.set(dupKey, PersistentDataType.INTEGER, level);
+
+        // give item a visual enchant glint
+        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        meta.addEnchant(Enchantment.DURABILITY, 1, true);
+
+        insertLoreLine(meta, ChatColor.LIGHT_PURPLE + "Duplicate " + roman(level));
+        item.setItemMeta(meta);
+    }
+
+    /**
+     * Handles durability reduction and lore update after a block is mined.
+     *
+     * @return true if the item is broken after the hit
+     */
+    public static boolean damage(ItemStack item, Plugin plugin) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        NamespacedKey maxKey = new NamespacedKey(plugin, "max_durability");
+        NamespacedKey curKey = new NamespacedKey(plugin, "durability");
+
+        Integer max = pdc.get(maxKey, PersistentDataType.INTEGER);
+        Integer cur = pdc.get(curKey, PersistentDataType.INTEGER);
+        if (max == null || cur == null) return false;
+
+        cur = Math.max(0, cur - 1);
+        pdc.set(curKey, PersistentDataType.INTEGER, cur);
+
+        List<String> lore = meta.getLore();
+        if (lore == null) lore = new ArrayList<>();
+        if (lore.size() < 2) {
+            lore.add(" ");
+        }
+        lore.set(1, formatDurability(cur, max));
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+        return cur <= 0;
+    }
+
+    public static int getDuplicateLevel(ItemStack item, Plugin plugin) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        NamespacedKey dupKey = new NamespacedKey(plugin, "duplicate");
+        Integer level = pdc.get(dupKey, PersistentDataType.INTEGER);
+        return level == null ? 0 : level;
+    }
+
+    private static void insertLoreLine(ItemMeta meta, String line) {
+        List<String> lore = meta.getLore();
+        if (lore == null) {
+            lore = new ArrayList<>();
+            lore.add(" ");
+            lore.add(" ");
+        } else {
+            while (lore.size() < 2) {
+                lore.add(" ");
+            }
+        }
+        lore.add(2, line);
+        meta.setLore(lore);
+    }
+
+    private static String formatDurability(int cur, int max) {
+        return ChatColor.GRAY + "Durability: " + cur + "/" + max;
+    }
+
+    private static String roman(int number) {
+        return switch (number) {
+            case 2 -> "II";
+            case 3 -> "III";
+            case 4 -> "IV";
+            case 5 -> "V";
+            default -> "I";
+        };
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
@@ -1,0 +1,74 @@
+package org.maks.mineSystemPlugin.tool;
+
+import java.util.Collection;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Listener handling custom tool behaviour such as durability and duplicate drops.
+ */
+public class ToolListener implements Listener {
+
+    private final Plugin plugin;
+
+    public ToolListener(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        ItemStack tool = player.getInventory().getItemInMainHand();
+        if (tool.getType() == Material.AIR) {
+            return;
+        }
+
+        if (!tool.hasItemMeta()) return;
+
+        // check canDestroy list
+        if (!canDestroy(tool, event.getBlock())) {
+            event.setCancelled(true);
+            return;
+        }
+
+        // duplicate drops
+        int dupLevel = CustomTool.getDuplicateLevel(tool, plugin);
+        if (dupLevel > 0) {
+            double chance = switch (dupLevel) {
+                case 1 -> 0.03;
+                case 2 -> 0.04;
+                case 3 -> 0.05;
+                default -> 0.0;
+            };
+            if (Math.random() < chance) {
+                Collection<ItemStack> drops = event.getBlock().getDrops(tool, player);
+                for (ItemStack drop : drops) {
+                    event.getBlock().getWorld().dropItemNaturally(event.getBlock().getLocation(), drop);
+                }
+            }
+        }
+
+        // durability handling
+        boolean broken = CustomTool.damage(tool, plugin);
+        if (broken) {
+            player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+        } else {
+            player.getInventory().setItemInMainHand(tool);
+        }
+    }
+
+    private boolean canDestroy(ItemStack tool, Block block) {
+        if (!tool.hasItemMeta()) return true;
+        var meta = tool.getItemMeta();
+        var canDestroy = meta.getCanDestroy();
+        if (canDestroy == null || canDestroy.isEmpty()) return true;
+        return canDestroy.contains(block.getType());
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/tool/ToolMaterial.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/ToolMaterial.java
@@ -1,0 +1,31 @@
+package org.maks.mineSystemPlugin.tool;
+
+import org.bukkit.Material;
+
+/**
+ * Enumeration of tool materials with custom maximum durability values.
+ */
+public enum ToolMaterial {
+    WOODEN(Material.WOODEN_PICKAXE, 2500),
+    STONE(Material.STONE_PICKAXE, 5000),
+    IRON(Material.IRON_PICKAXE, 20000),
+    GOLD(Material.GOLDEN_PICKAXE, 10000),
+    DIAMOND(Material.DIAMOND_PICKAXE, 50000),
+    NETHERITE(Material.NETHERITE_PICKAXE, 100000);
+
+    private final Material material;
+    private final int maxDurability;
+
+    ToolMaterial(Material material, int maxDurability) {
+        this.material = material;
+        this.maxDurability = maxDurability;
+    }
+
+    public Material getMaterial() {
+        return material;
+    }
+
+    public int getMaxDurability() {
+        return maxDurability;
+    }
+}


### PR DESCRIPTION
## Summary
- define tool materials from wooden to netherite with specific max durability
- add utility for custom tools: durability lore, Mining Speed and Duplicate enchants
- enforce CanDestroy restrictions, durability loss and duplicate drops on block break

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc5cf0a4832a8daba0f11b9ac068