### PR TITLE
Require premium ticket for sphere type 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
             <id>papermc-repo</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>mythiccraft-repo</id>
+            <url>https://repo.mythiccraft.io/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -62,6 +66,12 @@
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lumine</groupId>
+            <artifactId>Mythic-API</artifactId>
+            <version>5.6.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -2,11 +2,14 @@ package org.maks.mineSystemPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import org.maks.mineSystemPlugin.command.SphereCommand;
+
 public final class MineSystemPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
         // Plugin startup logic
+        getCommand("sphere").setExecutor(new SphereCommand());
 
     }
 

--- a/src/main/java/org/maks/mineSystemPlugin/command/SphereCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/command/SphereCommand.java
@@ -1,0 +1,84 @@
+package org.maks.mineSystemPlugin.command;
+
+import io.lumine.mythic.bukkit.MythicBukkit;
+import io.lumine.mythic.api.items.MythicItemManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+import java.util.Optional;
+
+/**
+ * Handles the creation of spheres via the /sphere command. When a player
+ * attempts to create a sphere of type 2 they must possess a MythicMobs item
+ * with the ID {@code mine_premium_ticket}. One instance of the item is
+ * consumed; otherwise the attempt is rejected.
+ */
+public class SphereCommand implements CommandExecutor {
+
+    private static final String PREMIUM_TICKET_ID = "mine_premium_ticket";
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players may use this command.");
+            return true;
+        }
+
+        if (args.length != 1) {
+            sender.sendMessage(ChatColor.RED + "Usage: /" + label + " <type>");
+            return true;
+        }
+
+        int type;
+        try {
+            type = Integer.parseInt(args[0]);
+        } catch (NumberFormatException ex) {
+            sender.sendMessage(ChatColor.RED + "Type must be a number.");
+            return true;
+        }
+
+        if (type == 2) {
+            if (!consumePremiumTicket(player)) {
+                player.sendMessage(ChatColor.RED + "You need a premium ticket to create this sphere!");
+                return true;
+            }
+        }
+
+        // Sphere creation logic would go here
+        player.sendMessage(ChatColor.GREEN + "Sphere type " + type + " created.");
+        return true;
+    }
+
+    /**
+     * Looks for the MythicMobs item in the player's inventory and removes one
+     * instance if found.
+     *
+     * @param player Player whose inventory is inspected
+     * @return true if an item was consumed, false otherwise
+     */
+    private boolean consumePremiumTicket(Player player) {
+        PlayerInventory inventory = player.getInventory();
+        MythicItemManager itemManager = MythicBukkit.inst().getItemManager();
+        for (int slot = 0; slot < inventory.getSize(); slot++) {
+            ItemStack stack = inventory.getItem(slot);
+            if (stack == null) continue;
+            Optional<String> mythicType = itemManager.getMythicType(stack);
+            if (mythicType.isPresent() && PREMIUM_TICKET_ID.equals(mythicType.get())) {
+                int amount = stack.getAmount();
+                if (amount > 1) {
+                    stack.setAmount(amount - 1);
+                } else {
+                    inventory.setItem(slot, null);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,7 @@ name: mineSystemPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.mineSystemPlugin.MineSystemPlugin
 api-version: '1.20'
+commands:
+  sphere:
+    description: Create a sphere
+    usage: /sphere <type>


### PR DESCRIPTION
## Summary
- add MythicMobs API dependency and repository
- introduce `/sphere` command that consumes a `mine_premium_ticket` MythicMobs item when creating type 2 spheres
- deny creation if the player lacks the ticket

## Testing
- `mvn -q -e package` *(fails: Network is unreachable retrieving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc5df38c832a87dc0c83e6986d77