### PR TITLE
Add ore mining rewards and double drop chance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
             <id>papermc-repo</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>mythiccraft-repo</id>
+            <url>https://repo.mythiccraft.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -62,6 +66,12 @@
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lumine</groupId>
+            <artifactId>Mythic-Dist</artifactId>
+            <version>5.6.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -1,17 +1,19 @@
 package org.maks.mineSystemPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.listener.OreBreakListener;
 
-public final class MineSystemPlugin extends JavaPlugin {
+public class MineSystemPlugin extends JavaPlugin {
+
+    private int globalOreCount = 0;
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
-
+        getServer().getPluginManager().registerEvents(new OreBreakListener(this), this);
     }
 
-    @Override
-    public void onDisable() {
-        // Plugin shutdown logic
+    public int incrementOreCount() {
+        return ++globalOreCount;
     }
 }
+

--- a/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
@@ -1,0 +1,58 @@
+package org.maks.mineSystemPlugin.listener;
+
+import io.lumine.mythic.bukkit.MythicBukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+public class OreBreakListener implements Listener {
+
+    private static final List<String> ORE_REWARDS = Arrays.asList("ore_I", "ore_II", "ore_III");
+
+    private final MineSystemPlugin plugin;
+    private final Random random = new Random();
+
+    public OreBreakListener(MineSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Block block = event.getBlock();
+        Material type = block.getType();
+        if (!type.toString().endsWith("_ORE")) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        Collection<ItemStack> drops = block.getDrops(player.getInventory().getItemInMainHand());
+        event.setDropItems(false);
+
+        for (ItemStack drop : drops) {
+            block.getWorld().dropItemNaturally(block.getLocation(), drop);
+            if (random.nextDouble() < 0.10) {
+                block.getWorld().dropItemNaturally(block.getLocation(), drop.clone());
+            }
+        }
+
+        int total = plugin.incrementOreCount();
+        if (total % 20 == 0) {
+            String rewardName = ORE_REWARDS.get(random.nextInt(ORE_REWARDS.size()));
+            ItemStack reward = MythicBukkit.inst().getItemManager().getItemStack(rewardName);
+            if (reward != null) {
+                block.getWorld().dropItemNaturally(block.getLocation(), reward);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Track global ore mining count and register event listener
- Drop MythicMobs ore_* item every 20th ore mined
- Add 10% chance to double natural ore drops and include MythicMobs dependency

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc5eab24832aaa394348987bf423