### PR TITLE
Add custom mining events for quest integration

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -1,6 +1,12 @@
 package org.maks.mineSystemPlugin;
 
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.events.OreMinedEvent;
+import org.maks.mineSystemPlugin.events.SphereCompleteEvent;
+
+import java.util.Map;
 
 public final class MineSystemPlugin extends JavaPlugin {
 
@@ -13,5 +19,26 @@ public final class MineSystemPlugin extends JavaPlugin {
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+    }
+
+    /**
+     * Reports that a player has mined a certain amount of ore. The event is dispatched so
+     * quest systems and other plugins can listen for mining progress.
+     */
+    public void reportOreMined(Player player, Material oreType, int amount, int pickaxeLevel) {
+        OreMinedEvent event = new OreMinedEvent(player, oreType, amount, pickaxeLevel);
+        getServer().getPluginManager().callEvent(event);
+    }
+
+    /**
+     * Reports that a player has completed a mining sphere.
+     *
+     * @param player      player who finished the sphere
+     * @param type        type of sphere that was completed
+     * @param statistics  statistics describing the completed sphere
+     */
+    public void reportSphereComplete(Player player, String type, Map<String, Integer> statistics) {
+        SphereCompleteEvent event = new SphereCompleteEvent(player, type, statistics);
+        getServer().getPluginManager().callEvent(event);
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/events/OreMinedEvent.java
+++ b/src/main/java/org/maks/mineSystemPlugin/events/OreMinedEvent.java
@@ -1,0 +1,51 @@
+package org.maks.mineSystemPlugin.events;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event fired whenever a player mines an ore. This can be used by quest
+ * systems and other plugins to track mining progress.
+ */
+public class OreMinedEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player player;
+    private final Material oreType;
+    private final int amount;
+    private final int pickaxeLevel;
+
+    public OreMinedEvent(Player player, Material oreType, int amount, int pickaxeLevel) {
+        this.player = player;
+        this.oreType = oreType;
+        this.amount = amount;
+        this.pickaxeLevel = pickaxeLevel;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Material getOreType() {
+        return oreType;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public int getPickaxeLevel() {
+        return pickaxeLevel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/events/SphereCompleteEvent.java
+++ b/src/main/java/org/maks/mineSystemPlugin/events/SphereCompleteEvent.java
@@ -1,0 +1,46 @@
+package org.maks.mineSystemPlugin.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.Map;
+
+/**
+ * Event fired when a player completes a mining sphere. This event allows
+ * quest systems and other plugins to react to the completion.
+ */
+public class SphereCompleteEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player player;
+    private final String type;
+    private final Map<String, Integer> statistics;
+
+    public SphereCompleteEvent(Player player, String type, Map<String, Integer> statistics) {
+        this.player = player;
+        this.type = type;
+        this.statistics = statistics;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Map<String, Integer> getStatistics() {
+        return statistics;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}


### PR DESCRIPTION
## Summary
- add `OreMinedEvent` with player, ore type, amount, and pickaxe level
- add `SphereCompleteEvent` with player, type, and statistics
- expose helper methods in `MineSystemPlugin` to dispatch these events so quest systems and other plugins can listen

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc5f1604832a85bbff531942f334