### PR TITLE
Add MySQL loot configuration and probability-based roll logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,5 +64,10 @@
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/maks/mineSystemPlugin/LootManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/LootManager.java
@@ -1,0 +1,45 @@
+package org.maks.mineSystemPlugin;
+
+import java.util.*;
+
+/**
+ * Handles randomisation logic for loot rolls.
+ */
+public class LootManager {
+    private final Random random = new Random();
+    private Map<String, Double> probabilities = new HashMap<>();
+
+    public void setProbabilities(Map<String, Double> probabilities) {
+        this.probabilities = probabilities;
+    }
+
+    /**
+     * Rolls number of items using normal distribution with mean 13.
+     * The value is clamped to range 1-27.
+     */
+    public int rollItemCount() {
+        int count = (int) Math.round(13 + random.nextGaussian() * 4);
+        if (count < 1) count = 1;
+        if (count > 27) count = 27;
+        return count;
+    }
+
+    /**
+     * Selects an item from configured probabilities.
+     */
+    public String rollItem() {
+        if (probabilities.isEmpty()) {
+            return null;
+        }
+        double total = probabilities.values().stream().mapToDouble(Double::doubleValue).sum();
+        double r = random.nextDouble() * total;
+        double cumulative = 0;
+        for (Map.Entry<String, Double> entry : probabilities.entrySet()) {
+            cumulative += entry.getValue();
+            if (r <= cumulative) {
+                return entry.getKey();
+            }
+        }
+        return probabilities.keySet().iterator().next();
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -1,17 +1,44 @@
 package org.maks.mineSystemPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.command.LootCommand;
+import org.maks.mineSystemPlugin.storage.MySqlStorage;
+
+import java.sql.SQLException;
+import java.util.logging.Level;
 
 public final class MineSystemPlugin extends JavaPlugin {
+    private MySqlStorage storage;
+    private LootManager lootManager;
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
-
+        saveDefaultConfig();
+        try {
+            String host = getConfig().getString("mysql.host");
+            int port = getConfig().getInt("mysql.port");
+            String database = getConfig().getString("mysql.database");
+            String user = getConfig().getString("mysql.username");
+            String pass = getConfig().getString("mysql.password");
+            String url = "jdbc:mysql://" + host + ":" + port + "/" + database;
+            storage = new MySqlStorage(url, user, pass);
+            lootManager = new LootManager();
+            lootManager.setProbabilities(storage.loadItems());
+            getCommand("loot").setExecutor(new LootCommand(storage, lootManager));
+        } catch (SQLException e) {
+            getLogger().log(Level.SEVERE, "Failed to connect to MySQL", e);
+            getServer().getPluginManager().disablePlugin(this);
+        }
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (storage != null) {
+            storage.close();
+        }
+    }
+
+    public LootManager getLootManager() {
+        return lootManager;
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/command/LootCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/command/LootCommand.java
@@ -1,0 +1,50 @@
+package org.maks.mineSystemPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.maks.mineSystemPlugin.LootManager;
+import org.maks.mineSystemPlugin.storage.MySqlStorage;
+
+import java.sql.SQLException;
+
+/**
+ * Simple command to manage loot table.
+ */
+public class LootCommand implements CommandExecutor {
+    private final MySqlStorage storage;
+    private final LootManager lootManager;
+
+    public LootCommand(MySqlStorage storage, LootManager lootManager) {
+        this.storage = storage;
+        this.lootManager = lootManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("/loot add <item> <chance>");
+            return true;
+        }
+        if (args.length == 3 && args[0].equalsIgnoreCase("add")) {
+            String item = args[1];
+            double chance;
+            try {
+                chance = Double.parseDouble(args[2]);
+            } catch (NumberFormatException ex) {
+                sender.sendMessage("Invalid chance value");
+                return true;
+            }
+            try {
+                storage.saveItem(item, chance);
+                lootManager.setProbabilities(storage.loadItems());
+                sender.sendMessage("Saved " + item + " with chance " + chance);
+            } catch (SQLException ex) {
+                sender.sendMessage("Database error: " + ex.getMessage());
+            }
+            return true;
+        }
+        sender.sendMessage("Unknown subcommand");
+        return true;
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/storage/MySqlStorage.java
+++ b/src/main/java/org/maks/mineSystemPlugin/storage/MySqlStorage.java
@@ -1,0 +1,47 @@
+package org.maks.mineSystemPlugin.storage;
+
+import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple JDBC backed storage for loot configuration.
+ * Configuration is stored in a table named <code>loot_items</code>
+ * where each row contains the MythicMobs item name and the chance in percent.
+ */
+public class MySqlStorage {
+    private final Connection connection;
+
+    public MySqlStorage(String url, String user, String password) throws SQLException {
+        this.connection = DriverManager.getConnection(url, user, password);
+        try (Statement st = connection.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS loot_items (item VARCHAR(64) PRIMARY KEY, chance DOUBLE)");
+        }
+    }
+
+    public void saveItem(String item, double chance) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement("REPLACE INTO loot_items(item, chance) VALUES(?, ?)")) {
+            ps.setString(1, item);
+            ps.setDouble(2, chance);
+            ps.executeUpdate();
+        }
+    }
+
+    public Map<String, Double> loadItems() throws SQLException {
+        Map<String, Double> map = new HashMap<>();
+        try (Statement st = connection.createStatement();
+             ResultSet rs = st.executeQuery("SELECT item, chance FROM loot_items")) {
+            while (rs.next()) {
+                map.put(rs.getString("item"), rs.getDouble("chance"));
+            }
+        }
+        return map;
+    }
+
+    public void close() {
+        try {
+            connection.close();
+        } catch (SQLException ignored) {
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+mysql:
+  host: localhost
+  port: 3306
+  database: minecraft
+  username: root
+  password: password

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,8 @@ name: mineSystemPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.mineSystemPlugin.MineSystemPlugin
 api-version: '1.20'
+commands:
+  loot:
+    description: Manage loot configuration
+    usage: /loot add <item> <chance>
+    permission: minesystemplugin.loot


### PR DESCRIPTION
## Summary
- Implement `MySqlStorage` to persist loot items and probabilities in a MySQL table
- Add `LootManager` with Gaussian-distributed item counts and percentage-based item selection
- Introduce `/loot add` command and configuration files for database setup

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc5fe268832aac05bd0882d3340d