### PR TITLE
Add basic stamina, sphere limit, and mob spawn configuration

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -1,17 +1,49 @@
 package org.maks.mineSystemPlugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.command.JoinSphereCommand;
+import org.maks.mineSystemPlugin.mob.MobSpawner;
+import org.maks.mineSystemPlugin.sphere.SphereManager;
+import org.maks.mineSystemPlugin.stamina.StaminaManager;
+
+import java.time.Duration;
 
 public final class MineSystemPlugin extends JavaPlugin {
 
+    private StaminaManager staminaManager;
+    private SphereManager sphereManager;
+    private MobSpawner mobSpawner;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        saveDefaultConfig();
 
+        int maxStamina = getConfig().getInt("maxStamina", 100);
+        int sphereLimit = getConfig().getInt("sphereLimit", 20);
+
+        this.staminaManager = new StaminaManager(this, maxStamina, Duration.ofHours(12));
+        this.mobSpawner = new MobSpawner(this);
+        this.sphereManager = new SphereManager(this, sphereLimit, mobSpawner);
+
+        if (getCommand("sphere") != null) {
+            getCommand("sphere").setExecutor(new JoinSphereCommand(this));
+        }
     }
 
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+    }
+
+    public StaminaManager getStaminaManager() {
+        return staminaManager;
+    }
+
+    public SphereManager getSphereManager() {
+        return sphereManager;
+    }
+
+    public MobSpawner getMobSpawner() {
+        return mobSpawner;
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/command/JoinSphereCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/command/JoinSphereCommand.java
@@ -1,0 +1,38 @@
+package org.maks.mineSystemPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+/**
+ * Simple command for testing stamina and sphere limits.
+ */
+public class JoinSphereCommand implements CommandExecutor {
+    private final MineSystemPlugin plugin;
+
+    public JoinSphereCommand(MineSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        int cost = 10;
+        if (!plugin.getStaminaManager().hasStamina(player.getUniqueId(), cost)) {
+            player.sendMessage("You are too tired to enter a sphere.");
+            return true;
+        }
+        if (!plugin.getSphereManager().canCreateSphere(player)) {
+            return true; // message handled in manager
+        }
+        plugin.getStaminaManager().deductStamina(player.getUniqueId(), cost);
+        plugin.getSphereManager().registerSphere(player);
+        player.sendMessage("Sphere created! (placeholder)");
+        return true;
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/mob/MobSpawner.java
+++ b/src/main/java/org/maks/mineSystemPlugin/mob/MobSpawner.java
@@ -1,0 +1,65 @@
+package org.maks.mineSystemPlugin.mob;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Spawns MythicMobs at a location using configured identifiers.
+ */
+public class MobSpawner {
+    private final MineSystemPlugin plugin;
+    private final List<MobEntry> entries = new ArrayList<>();
+    private final Random random = new Random();
+
+    public MobSpawner(MineSystemPlugin plugin) {
+        this.plugin = plugin;
+        load();
+    }
+
+    private void load() {
+        entries.clear();
+        ConfigurationSection section = plugin.getConfig().getConfigurationSection("mobSpawns");
+        if (section == null) {
+            return;
+        }
+        for (String key : section.getKeys(false)) {
+            String id = section.getString(key + ".id");
+            int amount = section.getInt(key + ".amount", 1);
+            int weight = section.getInt(key + ".weight", 1);
+            if (id != null && amount > 0 && weight > 0) {
+                entries.add(new MobEntry(id, amount, weight));
+            }
+        }
+    }
+
+    public void spawn(Location loc) {
+        if (entries.isEmpty() || loc == null) {
+            return;
+        }
+        MobEntry entry = getRandomEntry();
+        String cmd = String.format("mm m spawn %s %d %d %d %d", entry.id, entry.amount,
+                loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
+    }
+
+    private MobEntry getRandomEntry() {
+        int totalWeight = entries.stream().mapToInt(e -> e.weight).sum();
+        int roll = random.nextInt(totalWeight);
+        int cumulative = 0;
+        for (MobEntry entry : entries) {
+            cumulative += entry.weight;
+            if (roll < cumulative) {
+                return entry;
+            }
+        }
+        return entries.get(0);
+    }
+
+    private record MobEntry(String id, int amount, int weight) {}
+}

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -1,0 +1,48 @@
+package org.maks.mineSystemPlugin.sphere;
+
+import org.bukkit.entity.Player;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+import org.maks.mineSystemPlugin.mob.MobSpawner;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Tracks active spheres and enforces a global limit.
+ */
+public class SphereManager {
+    private final MineSystemPlugin plugin;
+    private final int limit;
+    private final Set<UUID> active = new HashSet<>();
+    private final MobSpawner mobSpawner;
+
+    /** Placeholder block replaced by actual ores when generating spheres. */
+    public static final Material ORE_PLACEHOLDER = Material.WHITE_WOOL;
+
+    public SphereManager(MineSystemPlugin plugin, int limit, MobSpawner mobSpawner) {
+        this.plugin = plugin;
+        this.limit = limit;
+        this.mobSpawner = mobSpawner;
+    }
+
+    public boolean canCreateSphere(Player player) {
+        if (active.size() >= limit) {
+            player.sendMessage("Too many active spheres. Please wait.");
+            return false;
+        }
+        return true;
+    }
+
+    public void registerSphere(Player player) {
+        active.add(player.getUniqueId());
+        Location center = player.getLocation();
+        mobSpawner.spawn(center);
+    }
+
+    public void removeSphere(Player player) {
+        active.remove(player.getUniqueId());
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/stamina/PlayerStamina.java
+++ b/src/main/java/org/maks/mineSystemPlugin/stamina/PlayerStamina.java
@@ -1,0 +1,31 @@
+package org.maks.mineSystemPlugin.stamina;
+
+import java.time.Instant;
+
+/**
+ * Simple POJO holding stamina information for a player.
+ */
+public class PlayerStamina {
+    private int stamina;
+    private Instant firstUsage;
+
+    public PlayerStamina(int stamina) {
+        this.stamina = stamina;
+    }
+
+    public int getStamina() {
+        return stamina;
+    }
+
+    public void setStamina(int stamina) {
+        this.stamina = stamina;
+    }
+
+    public Instant getFirstUsage() {
+        return firstUsage;
+    }
+
+    public void setFirstUsage(Instant firstUsage) {
+        this.firstUsage = firstUsage;
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/stamina/StaminaManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/stamina/StaminaManager.java
@@ -1,0 +1,64 @@
+package org.maks.mineSystemPlugin.stamina;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Handles stamina usage and timed resets for players.
+ */
+public class StaminaManager {
+    private final MineSystemPlugin plugin;
+    private final int maxStamina;
+    private final Map<UUID, PlayerStamina> staminaMap = new ConcurrentHashMap<>();
+    private final Duration resetAfter;
+
+    public StaminaManager(MineSystemPlugin plugin, int maxStamina, Duration resetAfter) {
+        this.plugin = plugin;
+        this.maxStamina = maxStamina;
+        this.resetAfter = resetAfter;
+        startResetTask();
+    }
+
+    private void startResetTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                Instant now = Instant.now();
+                staminaMap.forEach((uuid, ps) -> {
+                    if (ps.getFirstUsage() != null && now.isAfter(ps.getFirstUsage().plus(resetAfter))) {
+                        ps.setStamina(maxStamina);
+                        ps.setFirstUsage(null);
+                        Player p = Bukkit.getPlayer(uuid);
+                        if (p != null) {
+                            p.sendMessage("Your stamina has been refreshed.");
+                        }
+                    }
+                });
+            }
+        }.runTaskTimer(plugin, 20L * 60, 20L * 60); // check every minute
+    }
+
+    public int getStamina(UUID uuid) {
+        return staminaMap.computeIfAbsent(uuid, id -> new PlayerStamina(maxStamina)).getStamina();
+    }
+
+    public boolean hasStamina(UUID uuid, int amount) {
+        return getStamina(uuid) >= amount;
+    }
+
+    public void deductStamina(UUID uuid, int amount) {
+        PlayerStamina ps = staminaMap.computeIfAbsent(uuid, id -> new PlayerStamina(maxStamina));
+        if (ps.getFirstUsage() == null) {
+            ps.setFirstUsage(Instant.now());
+        }
+        ps.setStamina(Math.max(0, ps.getStamina() - amount));
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,12 @@
+# Default configuration for MineSystemPlugin
+maxStamina: 100
+sphereLimit: 20
+baseRepairCost: 32
+baseEnchantCost: 64
+
+# Example MythicMob spawn entries used when generating a sphere with mobs.
+mobSpawns:
+  example:
+    id: ExampleMob
+    amount: 3
+    weight: 1

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,6 @@ name: mineSystemPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.mineSystemPlugin.MineSystemPlugin
 api-version: '1.20'
+commands:
+  sphere:
+    description: Enter a mining sphere (test command)


### PR DESCRIPTION
## Summary
- Track player stamina with timed 12-hour reset
- Enforce a configurable global sphere limit and placeholder ore block
- Add configurable MythicMob spawns when creating a sphere

## Testing
- `mvn -q -e -B test` *(fails: PluginResolutionException, Could not resolve org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68947b1574f0832aadc8cecbd1c5a6e5