### PR TITLE
Add async repositories for player tables

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/model/PickaxeData.java
+++ b/src/main/java/org/maks/mineSystemPlugin/model/PickaxeData.java
@@ -1,0 +1,5 @@
+package org.maks.mineSystemPlugin.model;
+
+import java.util.UUID;
+
+public record PickaxeData(UUID uuid, String material, int durability, String enchants) {}

--- a/src/main/java/org/maks/mineSystemPlugin/model/PlayerData.java
+++ b/src/main/java/org/maks/mineSystemPlugin/model/PlayerData.java
@@ -1,0 +1,5 @@
+package org.maks.mineSystemPlugin.model;
+
+import java.util.UUID;
+
+public record PlayerData(UUID uuid, int stamina, long resetTimestamp) {}

--- a/src/main/java/org/maks/mineSystemPlugin/model/QuestData.java
+++ b/src/main/java/org/maks/mineSystemPlugin/model/QuestData.java
@@ -1,0 +1,5 @@
+package org.maks.mineSystemPlugin.model;
+
+import java.util.UUID;
+
+public record QuestData(UUID uuid, int progress) {}

--- a/src/main/java/org/maks/mineSystemPlugin/model/SphereData.java
+++ b/src/main/java/org/maks/mineSystemPlugin/model/SphereData.java
@@ -1,0 +1,5 @@
+package org.maks.mineSystemPlugin.model;
+
+import java.util.UUID;
+
+public record SphereData(UUID uuid, String type, long startTime) {}

--- a/src/main/java/org/maks/mineSystemPlugin/repository/PickaxeRepository.java
+++ b/src/main/java/org/maks/mineSystemPlugin/repository/PickaxeRepository.java
@@ -1,0 +1,55 @@
+package org.maks.mineSystemPlugin.repository;
+
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+import org.maks.mineSystemPlugin.model.PickaxeData;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class PickaxeRepository {
+    private final DatabaseManager database;
+
+    public PickaxeRepository(DatabaseManager database) {
+        this.database = database;
+    }
+
+    public CompletableFuture<Optional<PickaxeData>> load(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT material, durability, enchants FROM pickaxes WHERE uuid = ?";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, uuid.toString());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return Optional.of(new PickaxeData(uuid, rs.getString("material"), rs.getInt("durability"), rs.getString("enchants")));
+                    }
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+            return Optional.empty();
+        }, database.getExecutor());
+    }
+
+    public CompletableFuture<Void> save(PickaxeData data) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO pickaxes(uuid, material, durability, enchants) VALUES(?, ?, ?, ?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET material=excluded.material, durability=excluded.durability, enchants=excluded.enchants";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, data.uuid().toString());
+                ps.setString(2, data.material());
+                ps.setInt(3, data.durability());
+                ps.setString(4, data.enchants());
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }, database.getExecutor());
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/repository/PlayerRepository.java
+++ b/src/main/java/org/maks/mineSystemPlugin/repository/PlayerRepository.java
@@ -1,0 +1,54 @@
+package org.maks.mineSystemPlugin.repository;
+
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+import org.maks.mineSystemPlugin.model.PlayerData;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class PlayerRepository {
+    private final DatabaseManager database;
+
+    public PlayerRepository(DatabaseManager database) {
+        this.database = database;
+    }
+
+    public CompletableFuture<Optional<PlayerData>> load(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT stamina, reset_timestamp FROM players WHERE uuid = ?";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, uuid.toString());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return Optional.of(new PlayerData(uuid, rs.getInt("stamina"), rs.getLong("reset_timestamp")));
+                    }
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+            return Optional.empty();
+        }, database.getExecutor());
+    }
+
+    public CompletableFuture<Void> save(PlayerData data) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO players(uuid, stamina, reset_timestamp) VALUES(?, ?, ?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET stamina=excluded.stamina, reset_timestamp=excluded.reset_timestamp";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, data.uuid().toString());
+                ps.setInt(2, data.stamina());
+                ps.setLong(3, data.resetTimestamp());
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }, database.getExecutor());
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/repository/QuestRepository.java
+++ b/src/main/java/org/maks/mineSystemPlugin/repository/QuestRepository.java
@@ -1,0 +1,53 @@
+package org.maks.mineSystemPlugin.repository;
+
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+import org.maks.mineSystemPlugin.model.QuestData;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class QuestRepository {
+    private final DatabaseManager database;
+
+    public QuestRepository(DatabaseManager database) {
+        this.database = database;
+    }
+
+    public CompletableFuture<Optional<QuestData>> load(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT progress FROM quests WHERE uuid = ?";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, uuid.toString());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return Optional.of(new QuestData(uuid, rs.getInt("progress")));
+                    }
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+            return Optional.empty();
+        }, database.getExecutor());
+    }
+
+    public CompletableFuture<Void> save(QuestData data) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO quests(uuid, progress) VALUES(?, ?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET progress=excluded.progress";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, data.uuid().toString());
+                ps.setInt(2, data.progress());
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }, database.getExecutor());
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/repository/SphereRepository.java
+++ b/src/main/java/org/maks/mineSystemPlugin/repository/SphereRepository.java
@@ -1,0 +1,54 @@
+package org.maks.mineSystemPlugin.repository;
+
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+import org.maks.mineSystemPlugin.model.SphereData;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class SphereRepository {
+    private final DatabaseManager database;
+
+    public SphereRepository(DatabaseManager database) {
+        this.database = database;
+    }
+
+    public CompletableFuture<Optional<SphereData>> load(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            String sql = "SELECT type, start_time FROM spheres WHERE uuid = ?";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, uuid.toString());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return Optional.of(new SphereData(uuid, rs.getString("type"), rs.getLong("start_time")));
+                    }
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+            return Optional.empty();
+        }, database.getExecutor());
+    }
+
+    public CompletableFuture<Void> save(SphereData data) {
+        return CompletableFuture.runAsync(() -> {
+            String sql = "INSERT INTO spheres(uuid, type, start_time) VALUES(?, ?, ?) " +
+                    "ON CONFLICT(uuid) DO UPDATE SET type=excluded.type, start_time=excluded.start_time";
+            try (Connection connection = database.getDataSource().getConnection();
+                 PreparedStatement ps = connection.prepareStatement(sql)) {
+                ps.setString(1, data.uuid().toString());
+                ps.setString(2, data.type());
+                ps.setLong(3, data.startTime());
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }, database.getExecutor());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure schema for player, pickaxe, quest and sphere tables keyed by UUID
- add model records and asynchronous repositories with load/save methods

## Testing
- `mvn -q package` *(fails: Network is unreachable fetching maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6895ac3f7c9c832ab6d71ee6b57ea3de