### PR TITLE
Track stamina usage time and scale max with quests

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -12,6 +12,8 @@ import org.maks.mineSystemPlugin.command.LootCommand;
 import org.maks.mineSystemPlugin.command.SphereCommand;
 import org.maks.mineSystemPlugin.managers.PickaxeManager;
 import org.maks.mineSystemPlugin.stamina.StaminaManager;
+import org.maks.mineSystemPlugin.database.DatabaseManager;
+import org.maks.mineSystemPlugin.repository.QuestRepository;
 import org.maks.mineSystemPlugin.sphere.SphereManager;
 import org.maks.mineSystemPlugin.sphere.SphereListener;
 import org.maks.mineSystemPlugin.listener.BlockBreakListener;
@@ -39,6 +41,8 @@ public final class MineSystemPlugin extends JavaPlugin {
     private SphereManager sphereManager;
     private StaminaManager staminaManager;
     private PickaxeManager pickaxeManager;
+    private DatabaseManager database;
+    private QuestRepository questRepository;
 
     private final Map<Location, Integer> blockHits = new HashMap<>();
     private final Map<String, Integer> oreHits = new HashMap<>();
@@ -49,8 +53,11 @@ public final class MineSystemPlugin extends JavaPlugin {
         saveDefaultConfig();
         loadOreHitConfig();
 
+        database = new DatabaseManager(this);
+        questRepository = new QuestRepository(database);
+
         int maxStamina = getConfig().getInt("maxStamina", 100);
-        staminaManager = new StaminaManager(this, maxStamina, Duration.ofHours(24));
+        staminaManager = new StaminaManager(this, maxStamina, Duration.ofHours(12), questRepository);
         sphereManager = new SphereManager(this);
         pickaxeManager = new PickaxeManager(this);
         lootManager = new LootManager();
@@ -97,6 +104,9 @@ public final class MineSystemPlugin extends JavaPlugin {
         }
         if (storage != null) {
             storage.close();
+        }
+        if (database != null) {
+            database.close();
         }
     }
 

--- a/src/main/java/org/maks/mineSystemPlugin/stamina/PlayerStamina.java
+++ b/src/main/java/org/maks/mineSystemPlugin/stamina/PlayerStamina.java
@@ -7,10 +7,12 @@ import java.time.Instant;
  */
 public class PlayerStamina {
     private int stamina;
+    private int maxStamina;
     private Instant firstUsage;
 
-    public PlayerStamina(int stamina) {
-        this.stamina = stamina;
+    public PlayerStamina(int maxStamina) {
+        this.stamina = maxStamina;
+        this.maxStamina = maxStamina;
     }
 
     public int getStamina() {
@@ -19,6 +21,14 @@ public class PlayerStamina {
 
     public void setStamina(int stamina) {
         this.stamina = stamina;
+    }
+
+    public int getMaxStamina() {
+        return maxStamina;
+    }
+
+    public void setMaxStamina(int maxStamina) {
+        this.maxStamina = maxStamina;
     }
 
     public Instant getFirstUsage() {


### PR DESCRIPTION
## Summary
- store per-player max stamina and first usage timestamp
- compute max stamina from quest progress and reset after 12h
- initialize database & quest repositories for stamina management

## Testing
- `mvn -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895adf098c4832a9efa78e7c9a57ccd