### PR TITLE
Ensure CanDestroy persists and random crystal enchant

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -79,7 +79,7 @@ public final class MineSystemPlugin extends JavaPlugin {
         }
 
         getCommand("repair").setExecutor(new RepairCommand(this));
-        getCommand("crystalenchant").setExecutor(new CrystalEnchantCommand());
+        getCommand("crystalenchant").setExecutor(new CrystalEnchantCommand(this));
         getCommand("sphere").setExecutor(new SphereCommand());
         getCommand("spawnsphere").setExecutor(this);
 

--- a/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
@@ -132,6 +132,13 @@ public final class CustomTool {
         }
         lore.set(1, formatDurability(cur, max));
         meta.setLore(lore);
+
+        // Re-apply CanDestroy attribute to ensure it persists after lore update
+        Set<Material> destroy = meta.getCanDestroy();
+        if (destroy != null && !destroy.isEmpty()) {
+            meta.setCanDestroy(new HashSet<>(destroy));
+        }
+
         item.setItemMeta(meta);
         return cur <= 0;
     }


### PR DESCRIPTION
## Summary
- Preserve CanDestroy attribute when updating tool durability lore
- Enchant pickaxes using crystals with random Mining Speed and Duplicate levels
- Wire command with plugin instance

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895b2ecb360832a856d44d667ae8765