### PR TITLE
Add crystal enchant GUI with cost display

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -79,7 +79,9 @@ public final class MineSystemPlugin extends JavaPlugin {
         }
 
         getCommand("repair").setExecutor(new RepairCommand(this));
-        getCommand("crystalenchant").setExecutor(new CrystalEnchantCommand());
+        CrystalEnchantCommand ceCommand = new CrystalEnchantCommand(this);
+        getCommand("crystalenchant").setExecutor(ceCommand);
+        registerListener(ceCommand);
         getCommand("sphere").setExecutor(new SphereCommand());
         getCommand("spawnsphere").setExecutor(this);
 

--- a/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
@@ -127,11 +127,21 @@ public final class CustomTool {
 
         List<String> lore = meta.getLore();
         if (lore == null) lore = new ArrayList<>();
-        if (lore.size() < 2) {
-            lore.add(" ");
+        int durabilityIndex = findDurabilityIndex(lore);
+        String formatted = formatDurability(cur, max);
+        if (durabilityIndex == -1) {
+            lore.add(formatted);
+        } else {
+            lore.set(durabilityIndex, formatted);
         }
-        lore.set(1, formatDurability(cur, max));
         meta.setLore(lore);
+
+        // ensure CanDestroy is preserved when setting meta
+        var canDestroy = meta.getCanDestroy();
+        if (canDestroy != null && !canDestroy.isEmpty()) {
+            meta.setCanDestroy(new HashSet<>(canDestroy));
+        }
+
         item.setItemMeta(meta);
         return cur <= 0;
     }
@@ -149,19 +159,25 @@ public final class CustomTool {
         List<String> lore = meta.getLore();
         if (lore == null) {
             lore = new ArrayList<>();
-            lore.add(" ");
-            lore.add(" ");
-        } else {
-            while (lore.size() < 2) {
-                lore.add(" ");
-            }
         }
-        lore.add(2, line);
+        int durabilityIndex = findDurabilityIndex(lore);
+        int insertIndex = durabilityIndex == -1 ? lore.size() : durabilityIndex + 1;
+        lore.add(insertIndex, line);
         meta.setLore(lore);
     }
 
     private static String formatDurability(int cur, int max) {
         return ChatColor.GRAY + "Durability: " + cur + "/" + max;
+    }
+
+    private static int findDurabilityIndex(List<String> lore) {
+        for (int i = 0; i < lore.size(); i++) {
+            String stripped = ChatColor.stripColor(lore.get(i));
+            if (stripped != null && stripped.startsWith("Durability:")) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private static String roman(int number) {


### PR DESCRIPTION
## Summary
- Replace direct crystal enchant command with GUI showing cost and effect descriptions in English
- Register command as event listener to handle menu clicks and apply random enchants

## Testing
- `mvn -q -e test` *(fails: Network is unreachable for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6895b2ecb360832a856d44d667ae8765