### PR TITLE
Add duplication chance and global mining rewards

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -1,13 +1,19 @@
 package org.maks.mineSystemPlugin.listener;
 
+import io.lumine.mythic.bukkit.MythicBukkit;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.player.Player;
 import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
 
 /**
  * Handles custom mining logic. Each ore requires a configured number of hits
@@ -16,7 +22,10 @@ import org.maks.mineSystemPlugin.MineSystemPlugin;
  */
 public class BlockBreakListener implements Listener {
 
+    private static final List<String> ORE_REWARDS = Arrays.asList("ore_I", "ore_II", "ore_III");
+
     private final MineSystemPlugin plugin;
+    private final Random random = new Random();
 
     public BlockBreakListener(MineSystemPlugin plugin) {
         this.plugin = plugin;
@@ -41,9 +50,22 @@ public class BlockBreakListener implements Listener {
         // Give MythicMobs item via command dispatch to avoid compile dependency
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(),
                 String.format("mm items give %s %s 1", player.getName(), oreId));
+        if (random.nextDouble() < 0.10) {
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(),
+                    String.format("mm items give %s %s 1", player.getName(), oreId));
+        }
 
         // Remove the block and prevent default drops
         event.setDropItems(false);
         block.setType(Material.AIR);
+
+        int total = plugin.incrementOreCount();
+        if (total % 20 == 0) {
+            String rewardName = ORE_REWARDS.get(random.nextInt(ORE_REWARDS.size()));
+            ItemStack reward = MythicBukkit.inst().getItemManager().getItemStack(rewardName);
+            if (reward != null) {
+                block.getWorld().dropItemNaturally(block.getLocation(), reward);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add 10% loot duplication chance when custom blocks break
- Track total mined blocks and drop a reward every 20 breaks

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895b7d34f70832aa40893b342ba05d0