### PR TITLE
Add GUI-based loot editor with weighted chest generation

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/LootManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/LootManager.java
@@ -1,5 +1,9 @@
 package org.maks.mineSystemPlugin;
 
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
 import java.util.*;
 
 /**
@@ -7,39 +11,76 @@ import java.util.*;
  */
 public class LootManager {
     private final Random random = new Random();
-    private Map<String, Double> probabilities = new HashMap<>();
+    private Map<Material, Integer> probabilities = new HashMap<>();
 
-    public void setProbabilities(Map<String, Double> probabilities) {
+    /**
+     * Updates internal probabilities map. Key is item material, value is chance in percent.
+     */
+    public void setProbabilities(Map<Material, Integer> probabilities) {
         this.probabilities = probabilities;
     }
 
+    // Probability distribution for number of rewards in a chest, index 0 corresponds to count=1
+    private static final double[] COUNT_DISTRIBUTION = {
+            0.03, 0.08, 0.20, 0.46, 0.95, 1.79, 3.05, 4.90, 7.44,
+            10.51, 13.72, 16.34, 18.02, 18.90, 18.02, 16.34, 13.72,
+            10.51, 7.44, 4.90, 3.05, 1.79, 0.95, 0.46, 0.20, 0.08,
+            0.03
+    };
+
     /**
-     * Rolls number of items using normal distribution with mean 13.
-     * The value is clamped to range 1-27.
+     * Rolls number of items using predefined probability distribution.
      */
     public int rollItemCount() {
-        int count = (int) Math.round(13 + random.nextGaussian() * 4);
-        if (count < 1) count = 1;
-        if (count > 27) count = 27;
-        return count;
+        double roll = random.nextDouble() * 100.0;
+        double cumulative = 0;
+        for (int i = 0; i < COUNT_DISTRIBUTION.length; i++) {
+            cumulative += COUNT_DISTRIBUTION[i];
+            if (roll <= cumulative) {
+                return i + 1;
+            }
+        }
+        return COUNT_DISTRIBUTION.length; // fallback
     }
 
     /**
-     * Selects an item from configured probabilities.
+     * Selects an item material from configured probabilities.
      */
-    public String rollItem() {
+    public Material rollItem() {
         if (probabilities.isEmpty()) {
             return null;
         }
-        double total = probabilities.values().stream().mapToDouble(Double::doubleValue).sum();
-        double r = random.nextDouble() * total;
-        double cumulative = 0;
-        for (Map.Entry<String, Double> entry : probabilities.entrySet()) {
+        int total = probabilities.values().stream().mapToInt(Integer::intValue).sum();
+        if (total <= 0) {
+            return null;
+        }
+        int r = random.nextInt(total);
+        int cumulative = 0;
+        for (Map.Entry<Material, Integer> entry : probabilities.entrySet()) {
             cumulative += entry.getValue();
-            if (r <= cumulative) {
+            if (r < cumulative) {
                 return entry.getKey();
             }
         }
         return probabilities.keySet().iterator().next();
+    }
+
+    /**
+     * Fills provided inventory with randomly selected items according to configured probabilities.
+     * Items are placed into random empty slots.
+     */
+    public void fillInventory(Inventory inventory) {
+        int count = rollItemCount();
+        List<Integer> slots = new ArrayList<>();
+        for (int i = 0; i < inventory.getSize(); i++) {
+            slots.add(i);
+        }
+        Collections.shuffle(slots, random);
+        for (int i = 0; i < count && i < slots.size(); i++) {
+            Material material = rollItem();
+            if (material != null) {
+                inventory.setItem(slots.get(i), new ItemStack(material));
+            }
+        }
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -107,7 +107,7 @@ public final class MineSystemPlugin extends JavaPlugin {
             String url = "jdbc:mysql://" + host + ":" + port + "/" + database;
             storage = new MySqlStorage(url, user, pass);
             lootManager.setProbabilities(storage.loadItems());
-            getCommand("loot").setExecutor(new LootCommand(storage, lootManager));
+            getCommand("loot").setExecutor(new LootCommand(this, storage, lootManager));
         } catch (SQLException e) {
             getLogger().log(Level.SEVERE, "Failed to connect to MySQL", e);
             getServer().getPluginManager().disablePlugin(this);

--- a/src/main/java/org/maks/mineSystemPlugin/command/LootCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/command/LootCommand.java
@@ -1,50 +1,53 @@
 package org.maks.mineSystemPlugin.command;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.maks.mineSystemPlugin.LootManager;
+import org.maks.mineSystemPlugin.menu.LootEditMenu;
 import org.maks.mineSystemPlugin.storage.MySqlStorage;
 
-import java.sql.SQLException;
-
 /**
- * Simple command to manage loot table.
+ * Command for managing loot configuration.
  */
 public class LootCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
     private final MySqlStorage storage;
     private final LootManager lootManager;
 
-    public LootCommand(MySqlStorage storage, LootManager lootManager) {
+    public LootCommand(JavaPlugin plugin, MySqlStorage storage, LootManager lootManager) {
+        this.plugin = plugin;
         this.storage = storage;
         this.lootManager = lootManager;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (args.length == 0) {
-            sender.sendMessage("/loot add <item> <chance>");
-            return true;
-        }
-        if (args.length == 3 && args[0].equalsIgnoreCase("add")) {
-            String item = args[1];
-            double chance;
-            try {
-                chance = Double.parseDouble(args[2]);
-            } catch (NumberFormatException ex) {
-                sender.sendMessage("Invalid chance value");
+        if (args.length == 1 && args[0].equalsIgnoreCase("gui")) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage("Only players can use this command.");
                 return true;
             }
-            try {
-                storage.saveItem(item, chance);
-                lootManager.setProbabilities(storage.loadItems());
-                sender.sendMessage("Saved " + item + " with chance " + chance);
-            } catch (SQLException ex) {
-                sender.sendMessage("Database error: " + ex.getMessage());
-            }
+            LootEditMenu menu = new LootEditMenu(plugin, storage, lootManager);
+            player.openInventory(menu.getInventory());
             return true;
         }
-        sender.sendMessage("Unknown subcommand");
+        if (args.length == 1 && args[0].equalsIgnoreCase("test")) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage("Only players can use this command.");
+                return true;
+            }
+            Inventory inv = Bukkit.createInventory(null, 27, "Loot Test");
+            lootManager.fillInventory(inv);
+            player.openInventory(inv);
+            return true;
+        }
+        sender.sendMessage("/loot gui - edit loot table");
+        sender.sendMessage("/loot test - preview generated loot");
         return true;
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/menu/LootEditMenu.java
+++ b/src/main/java/org/maks/mineSystemPlugin/menu/LootEditMenu.java
@@ -1,0 +1,123 @@
+package org.maks.mineSystemPlugin.menu;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.LootManager;
+import org.maks.mineSystemPlugin.storage.MySqlStorage;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Inventory GUI for editing loot items and their chances.
+ */
+public class LootEditMenu implements InventoryHolder, Listener {
+    private final JavaPlugin plugin;
+    private final MySqlStorage storage;
+    private final LootManager lootManager;
+    private final Inventory inventory;
+
+    public LootEditMenu(JavaPlugin plugin, MySqlStorage storage, LootManager lootManager) {
+        this.plugin = plugin;
+        this.storage = storage;
+        this.lootManager = lootManager;
+        this.inventory = Bukkit.createInventory(this, 27, ChatColor.DARK_GREEN + "Loot Editor");
+
+        Map<Material, Integer> items;
+        try {
+            items = storage.loadItems();
+        } catch (SQLException e) {
+            items = new HashMap<>();
+            plugin.getLogger().severe("Failed to load loot items: " + e.getMessage());
+        }
+        for (Map.Entry<Material, Integer> entry : items.entrySet()) {
+            ItemStack item = new ItemStack(entry.getKey());
+            ItemMeta meta = item.getItemMeta();
+            meta.setLore(List.of(ChatColor.YELLOW + "Chance: " + entry.getValue() + "%"));
+            item.setItemMeta(meta);
+            inventory.addItem(item);
+        }
+
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getInventory().getHolder() != this) {
+            return;
+        }
+        if (event.getClickedInventory() != inventory) {
+            return;
+        }
+        ItemStack item = event.getCurrentItem();
+        if (item == null || item.getType() == Material.AIR) {
+            return;
+        }
+        event.setCancelled(true);
+        ItemMeta meta = item.getItemMeta();
+        int chance = parseChance(meta);
+        if (event.isLeftClick()) {
+            chance = Math.min(100, chance + 1);
+        } else if (event.isRightClick()) {
+            chance = Math.max(0, chance - 1);
+        }
+        meta.setLore(List.of(ChatColor.YELLOW + "Chance: " + chance + "%"));
+        item.setItemMeta(meta);
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getInventory().getHolder() != this) {
+            return;
+        }
+        HandlerList.unregisterAll(this);
+        Map<Material, Integer> map = new HashMap<>();
+        for (ItemStack item : inventory.getContents()) {
+            if (item == null || item.getType() == Material.AIR) {
+                continue;
+            }
+            int chance = parseChance(item.getItemMeta());
+            if (chance > 0) {
+                map.put(item.getType(), chance);
+            }
+        }
+        try {
+            storage.saveItems(map);
+            lootManager.setProbabilities(map);
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Failed to save loot items: " + e.getMessage());
+        }
+    }
+
+    private int parseChance(ItemMeta meta) {
+        if (meta == null || meta.getLore() == null || meta.getLore().isEmpty()) {
+            return 0;
+        }
+        String line = ChatColor.stripColor(meta.getLore().get(0));
+        if (line.startsWith("Chance: ")) {
+            try {
+                return Integer.parseInt(line.substring(8, line.length() - 1));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary
- Add MySQL-backed loot storage using Material + percent chance
- Implement LootManager with predefined item count distribution and random inventory filling
- Introduce inventory GUI to insert items and tweak chances with left/right clicks
- Extend `/loot` command with GUI editor and loot preview

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895c23889b8832ab0a0892b6ef12574