### PR TITLE
Emit mining events and document listener registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# MineSystemPlugin
+
+This plugin adds custom mining mechanics such as timed spheres and special ores.
+
+## Registering Event Listeners
+
+Event listeners are registered through the Bukkit `PluginManager`. The main plugin
+class exposes a helper method for convenience:
+
+```java
+private void registerListener(Listener listener) {
+    getServer().getPluginManager().registerEvents(listener, this);
+}
+```
+
+Call this method from `onEnable` to hook your listener:
+
+```java
+@Override
+public void onEnable() {
+    registerListener(new MyCustomListener());
+}
+```
+
+Your listener can then react to custom events like `OreMinedEvent` and
+`SphereCompleteEvent`.

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -1,5 +1,6 @@
 package org.maks.mineSystemPlugin.listener;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
@@ -8,6 +9,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.player.Player;
 import org.maks.mineSystemPlugin.MineSystemPlugin;
+import org.maks.mineSystemPlugin.events.OreMinedEvent;
 import org.maks.mineSystemPlugin.item.CustomItems;
 import org.maks.mineSystemPlugin.tool.CustomTool;
 
@@ -41,6 +43,7 @@ public class BlockBreakListener implements Listener {
 
         Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
+        Material oreType = block.getType();
 
         String oreId = plugin.resolveOreId(block);
         int remaining = plugin.decrementBlockHits(block.getLocation(), oreId);
@@ -71,6 +74,10 @@ public class BlockBreakListener implements Listener {
         }
 
         block.setType(Material.AIR);
+
+        int amount = drop == null ? 0 : (duplicate ? drop.getAmount() * 2 : drop.getAmount());
+        int pickaxeLevel = CustomTool.getToolLevel(tool);
+        Bukkit.getPluginManager().callEvent(new OreMinedEvent(player, oreType, amount, pickaxeLevel));
 
         int total = plugin.incrementOreCount();
         if (total % 20 == 0) {

--- a/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
@@ -1,5 +1,6 @@
 package org.maks.mineSystemPlugin.listener;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -8,7 +9,9 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.maks.mineSystemPlugin.MineSystemPlugin;
+import org.maks.mineSystemPlugin.events.OreMinedEvent;
 import org.maks.mineSystemPlugin.item.CustomItems;
+import org.maks.mineSystemPlugin.tool.CustomTool;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,12 +39,17 @@ public class OreBreakListener implements Listener {
         }
 
         Player player = event.getPlayer();
-        Collection<ItemStack> drops = block.getDrops(player.getInventory().getItemInMainHand());
+        ItemStack tool = player.getInventory().getItemInMainHand();
+        Collection<ItemStack> drops = block.getDrops(tool);
         event.setDropItems(false);
 
         for (ItemStack drop : drops) {
             block.getWorld().dropItemNaturally(block.getLocation(), drop);
         }
+
+        int amount = drops.stream().mapToInt(ItemStack::getAmount).sum();
+        int pickaxeLevel = CustomTool.getToolLevel(tool);
+        Bukkit.getPluginManager().callEvent(new OreMinedEvent(player, type, amount, pickaxeLevel));
 
         int total = plugin.incrementOreCount();
         if (total % 20 == 0) {

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -20,6 +20,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
+import org.maks.mineSystemPlugin.events.SphereCompleteEvent;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -144,6 +145,12 @@ public class SphereManager {
         Sphere sphere = active.remove(uuid);
         if (sphere != null) {
             sphere.remove();
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null) {
+                Bukkit.getPluginManager().callEvent(
+                        new SphereCompleteEvent(player, sphere.getType().name(), Map.of())
+                );
+            }
         }
     }
 

--- a/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
@@ -155,6 +155,23 @@ public final class CustomTool {
         return level == null ? 0 : level;
     }
 
+    /**
+     * Determines the tool level based on its material. The lowest tier
+     * (wooden) is level 1 while the highest (netherite) is level 6. If the
+     * item does not match any known pickaxe material the level is 0.
+     */
+    public static int getToolLevel(ItemStack item) {
+        Material type = item.getType();
+        int level = 1;
+        for (ToolMaterial material : ToolMaterial.values()) {
+            if (material.getMaterial() == type) {
+                return level;
+            }
+            level++;
+        }
+        return 0;
+    }
+
     private static void insertLoreLine(ItemMeta meta, String line) {
         List<String> lore = meta.getLore();
         if (lore == null) {


### PR DESCRIPTION
## Summary
- fire `OreMinedEvent` after a custom or vanilla ore is broken and report ore type, amount and pickaxe level
- dispatch `SphereCompleteEvent` when a player's sphere is removed
- add `CustomTool.getToolLevel` utility
- document listener registration in README

## Testing
- `mvn -q test` *(fails: could not resolve maven-resources-plugin, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895c91ada40832aa3e0bfad3a7364e0