### PR TITLE
Fix WorldEdit and Player imports

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -7,7 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.player.Player;
+import org.bukkit.entity.Player;
 import org.maks.mineSystemPlugin.MineSystemPlugin;
 import org.maks.mineSystemPlugin.events.OreMinedEvent;
 import org.maks.mineSystemPlugin.item.CustomItems;

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/Sphere.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/Sphere.java
@@ -5,7 +5,7 @@ import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
-import com.sk89q.worldedit.session.EditSession;
+import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -66,7 +66,10 @@ public class Sphere {
                 entity.remove();
             }
         }
-        try (EditSession session = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(world))) {
+        try (EditSession session = WorldEdit.getInstance()
+                .newEditSessionBuilder()
+                .world(BukkitAdapter.adapt(world))
+                .build()) {
             for (BlockVector3 vec : region) {
                 session.setBlock(vec, BlockTypes.AIR.getDefaultState());
             }

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -12,7 +12,7 @@ import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.regions.CuboidRegion;
-import com.sk89q.worldedit.session.EditSession;
+import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.world.block.BlockState;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -172,7 +172,10 @@ public class SphereManager {
             Clipboard clipboard = reader.read();
             Map<BlockVector3, OreVariant> variants = replacePlaceholders(clipboard, premium);
 
-            try (EditSession editSession = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(origin.getWorld()))) {
+            try (EditSession editSession = WorldEdit.getInstance()
+                    .newEditSessionBuilder()
+                    .world(BukkitAdapter.adapt(origin.getWorld()))
+                    .build()) {
                 Operation operation = new com.sk89q.worldedit.extent.clipboard.ClipboardHolder(clipboard)
                         .createPaste(editSession)
                         .to(BlockVector3.at(origin.getBlockX(), origin.getBlockY(), origin.getBlockZ()))


### PR DESCRIPTION
## Summary
- Replace obsolete `com.sk89q.worldedit.session.EditSession` import with `com.sk89q.worldedit.EditSession`
- Create edit sessions via the `newEditSessionBuilder()` API
- Correct Player import to use `org.bukkit.entity.Player`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896280c6c0c832a97344e9efb0b4151