### PR TITLE
Add ore selling GUI and shop shortcut with Vault economy integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>5.0.1</version>

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -8,6 +8,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.plugin.RegisteredServiceProvider;
 
 import org.maks.mineSystemPlugin.command.LootCommand;
 import org.maks.mineSystemPlugin.command.MineCommand;
@@ -49,6 +51,7 @@ public final class MineSystemPlugin extends JavaPlugin {
     private LootRepository lootRepository;
     private SpecialLootManager specialLootManager;
     private SpecialLootRepository specialLootRepository;
+    private Economy economy;
 
     private static final Map<String, Integer> ORE_DURABILITY = Map.ofEntries(
             Map.entry("Hematite", 40),
@@ -91,6 +94,7 @@ public final class MineSystemPlugin extends JavaPlugin {
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        setupEconomy();
         database = new DatabaseManager(this);
         questRepository = new QuestRepository(database);
 
@@ -120,6 +124,18 @@ public final class MineSystemPlugin extends JavaPlugin {
         registerListener(new BlockBreakListener(this));
         registerListener(new OreBreakListener(this));
         registerListener(new ToolListener(this));
+    }
+
+    private void setupEconomy() {
+        if (!getServer().getPluginManager().isPluginEnabled("Vault")) {
+            getLogger().severe("Vault plugin not found, disabling plugin");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
+        if (rsp != null) {
+            economy = rsp.getProvider();
+        }
     }
 
     private void registerListener(Listener listener) {
@@ -164,6 +180,10 @@ public final class MineSystemPlugin extends JavaPlugin {
 
     public SpecialLootManager getSpecialLootManager() {
         return specialLootManager;
+    }
+
+    public Economy getEconomy() {
+        return economy;
     }
 
     public boolean isCustomOre(Material material) {

--- a/src/main/java/org/maks/mineSystemPlugin/menu/MineMenu.java
+++ b/src/main/java/org/maks/mineSystemPlugin/menu/MineMenu.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.permissions.PermissionAttachment;
 import org.maks.mineSystemPlugin.sphere.SphereManager;
 
 /**
@@ -45,6 +46,22 @@ public class MineMenu implements InventoryHolder, Listener {
             premium.setItemMeta(premiumMeta);
         }
         inventory.setItem(5, premium);
+
+        ItemStack shop = new ItemStack(Material.EMERALD);
+        ItemMeta shopMeta = shop.getItemMeta();
+        if (shopMeta != null) {
+            shopMeta.setDisplayName(ChatColor.GREEN + "Mine Shop");
+            shop.setItemMeta(shopMeta);
+        }
+        inventory.setItem(1, shop);
+
+        ItemStack sell = new ItemStack(Material.CHEST);
+        ItemMeta sellMeta = sell.getItemMeta();
+        if (sellMeta != null) {
+            sellMeta.setDisplayName(ChatColor.GOLD + "Sell Ores");
+            sell.setItemMeta(sellMeta);
+        }
+        inventory.setItem(7, sell);
 
         Bukkit.getPluginManager().registerEvents(this, plugin);
     }
@@ -79,6 +96,25 @@ public class MineMenu implements InventoryHolder, Listener {
                 }
             } else {
                 player.sendMessage(ChatColor.RED + "You need a Premium Mine Voucher to enter!");
+            }
+        } else if (name.equalsIgnoreCase("Sell Ores")) {
+            player.closeInventory();
+            if (plugin instanceof org.maks.mineSystemPlugin.MineSystemPlugin main) {
+                if (main.getEconomy() != null) {
+                    SellMenu menu = new SellMenu(plugin, main.getEconomy());
+                    player.openInventory(menu.getInventory());
+                } else {
+                    player.sendMessage(ChatColor.RED + "Economy unavailable");
+                }
+            }
+        } else if (name.equalsIgnoreCase("Mine Shop")) {
+            player.closeInventory();
+            if (!player.hasPermission("mycraftingplugin.use")) {
+                PermissionAttachment attachment = player.addAttachment(plugin, "mycraftingplugin.use", true);
+                player.performCommand("mine_shop");
+                attachment.remove();
+            } else {
+                player.performCommand("mine_shop");
             }
         }
     }

--- a/src/main/java/org/maks/mineSystemPlugin/menu/SellMenu.java
+++ b/src/main/java/org/maks/mineSystemPlugin/menu/SellMenu.java
@@ -1,0 +1,145 @@
+package org.maks.mineSystemPlugin.menu;
+
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * GUI allowing players to sell mined ores for Vault currency.
+ */
+public class SellMenu implements InventoryHolder, Listener {
+    private final JavaPlugin plugin;
+    private final Economy economy;
+    private final Inventory inventory;
+    private final ItemStack sellButton;
+    private static final int SELL_SLOT = 26;
+
+    public SellMenu(JavaPlugin plugin, Economy economy) {
+        this.plugin = plugin;
+        this.economy = economy;
+        this.inventory = Bukkit.createInventory(this, 27, ChatColor.GOLD + "Sell Ores");
+        this.sellButton = createSellButton();
+        inventory.setItem(SELL_SLOT, sellButton);
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    private ItemStack createSellButton() {
+        ItemStack item = new ItemStack(Material.EMERALD);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.GREEN + "Sell");
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    private boolean isOre(Material mat) {
+        return mat.name().endsWith("_ORE");
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getInventory().getHolder() != this) {
+            return;
+        }
+        if (event.getSlot() == SELL_SLOT && event.getClickedInventory() == inventory) {
+            event.setCancelled(true);
+            sellItems((Player) event.getWhoClicked());
+            return;
+        }
+        ItemStack item = event.getCurrentItem();
+        if (event.getClickedInventory() == inventory) {
+            if (event.getSlot() == SELL_SLOT) {
+                event.setCancelled(true);
+                return;
+            }
+            if (item != null && !isOre(item.getType())) {
+                event.setCancelled(true);
+            }
+        } else if (event.isShiftClick()) {
+            if (item != null && !isOre(item.getType())) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (event.getInventory().getHolder() != this) {
+            return;
+        }
+        for (ItemStack item : event.getNewItems().values()) {
+            if (item != null && !isOre(item.getType())) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+        if (event.getRawSlots().contains(SELL_SLOT)) {
+            event.setCancelled(true);
+        }
+    }
+
+    private void sellItems(Player player) {
+        double total = 0;
+        String base = player.getWorld().getName();
+        for (int i = 0; i < inventory.getSize(); i++) {
+            if (i == SELL_SLOT) {
+                continue;
+            }
+            ItemStack item = inventory.getItem(i);
+            if (item == null || item.getType() == Material.AIR) {
+                continue;
+            }
+            Material mat = item.getType();
+            if (!isOre(mat)) {
+                continue;
+            }
+            double price = plugin.getConfig().getDouble("sell-prices." + base + "." + mat.name(), 0.0);
+            total += price * item.getAmount();
+            inventory.setItem(i, null);
+        }
+        inventory.setItem(SELL_SLOT, sellButton);
+        if (total > 0) {
+            economy.depositPlayer(player, total);
+            player.sendMessage(ChatColor.GREEN + "Sold ores for $" + total);
+        } else {
+            player.sendMessage(ChatColor.RED + "No ores to sell");
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (event.getInventory().getHolder() != this) {
+            return;
+        }
+        Player player = (Player) event.getPlayer();
+        for (int i = 0; i < inventory.getSize(); i++) {
+            if (i == SELL_SLOT) {
+                continue;
+            }
+            ItemStack item = inventory.getItem(i);
+            if (item != null && item.getType() != Material.AIR) {
+                player.getInventory().addItem(item);
+            }
+        }
+        HandlerList.unregisterAll(this);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,3 +10,8 @@ database:
   name: minesystem
   user: root
   password: password
+
+sell-prices:
+  world:
+    COAL_ORE: 1.0
+    IRON_ORE: 2.0

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: MineSystemPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.mineSystemPlugin.MineSystemPlugin
 api-version: '1.20'
+depend: [Vault]
 commands:
   loot:
     description: Manage loot configuration


### PR DESCRIPTION
## Summary
- add SellMenu inventory to convert ores into Vault currency
- link SellMenu from /mine GUI and hook Vault economy
- expose per-base ore prices in config and depend on Vault
- add Mine Shop button that grants `mycraftingplugin.use` and runs `/mine_shop`

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689731ff3fec832ab9ac6bef69172ef5