### PR TITLE
Spawn player above gold block markers

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -314,6 +314,12 @@ public class SphereManager {
 
     private Location findSafeLocation(Region region, World world) {
         for (BlockVector3 vec : region) {
+            Block block = world.getBlockAt(vec.getX(), vec.getY(), vec.getZ());
+            if (block.getType() == Material.GOLD_BLOCK && block.getRelative(0, 1, 0).getType() == Material.AIR) {
+                return block.getLocation().add(0.5, 1, 0.5);
+            }
+        }
+        for (BlockVector3 vec : region) {
             Location loc = new Location(world, vec.getX(), vec.getY(), vec.getZ());
             if (world.getBlockAt(loc).getType() == Material.AIR && world.getBlockAt(loc.clone().add(0, 1, 0)).getType() == Material.AIR) {
                 return loc.add(0.5, 0, 0.5);


### PR DESCRIPTION
## Summary
- Spawn player above gold block markers inside spheres

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898c780ca54832abe31ebf7c7fdb5e4