### PR TITLE
Add extra sphere types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 This plugin adds custom mining mechanics such as timed spheres and special ores.
 
+## Sphere schematics
+
+Schematics are loaded from `plugins/MineSystemPlugin/schematics/<Type>` where
+`<Type>` is one of:
+
+- `Ore`
+- `Treasure`
+- `Vegetation`
+- `Mob`
+- `Boss`
+- `SpecialEvent`
+- `Puzzle`
+- `CrystalDust`
+
+Files can have any name as long as they end with the `.schem` extension. The
+plugin randomly selects the sphere type based on configured weights and then
+chooses a random schematic from the corresponding folder.
+
 ## Registering Event Listeners
 
 Event listeners are registered through the Bukkit `PluginManager`. The main plugin

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereType.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereType.java
@@ -10,7 +10,12 @@ import java.util.Random;
 public enum SphereType {
     ORE("Ore", 45),
     TREASURE("Treasure", 11),
-    DEFAULT("Default", 44);
+    VEGETATION("Vegetation", 15),
+    MOB("Mob", 15),
+    BOSS("Boss", 3),
+    SPECIAL_EVENT("SpecialEvent", 5),
+    PUZZLE("Puzzle", 7),
+    CRYSTAL_DUST("CrystalDust", 5);
 
     private static final Random RANDOM = new Random();
 


### PR DESCRIPTION
## Summary
- extend `SphereType` with Vegetation, Mob, Boss, Special Event, Puzzle, and Crystal Dust variants
- document schematic folder names for all sphere types

## Testing
- `mvn -q -e -DskipTests=true package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68999d18a770832a9684458532deec16