### PR TITLE
Add custom ore pricing support

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/item/CustomItems.java
+++ b/src/main/java/org/maks/mineSystemPlugin/item/CustomItems.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public final class CustomItems {
 
     private static final Map<String, ItemStack> ITEMS = new HashMap<>();
+    private static final Map<String, String> NAME_TO_ID = new HashMap<>();
 
     static {
         // Black Ore (Coal-based)
@@ -149,6 +150,9 @@ public final class CustomItems {
         }
         stack.setItemMeta(meta);
         ITEMS.put(id, stack);
+        if (meta.hasDisplayName()) {
+            NAME_TO_ID.put(meta.getDisplayName(), id);
+        }
     }
 
     /**
@@ -158,6 +162,20 @@ public final class CustomItems {
     public static ItemStack get(String id) {
         ItemStack stack = ITEMS.get(id);
         return stack != null ? stack.clone() : null;
+    }
+
+    /**
+     * Attempts to resolve the registered id for a given item instance.
+     */
+    public static String getId(ItemStack stack) {
+        if (stack == null) {
+            return null;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null && meta.hasDisplayName()) {
+            return NAME_TO_ID.get(meta.getDisplayName());
+        }
+        return null;
     }
 
     private CustomItems() {

--- a/src/main/java/org/maks/mineSystemPlugin/menu/SellMenu.java
+++ b/src/main/java/org/maks/mineSystemPlugin/menu/SellMenu.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.item.CustomItems;
 
 /**
  * GUI allowing players to sell mined ores for Vault currency.
@@ -112,7 +113,13 @@ public class SellMenu implements InventoryHolder, Listener {
             if (!isOre(mat)) {
                 continue;
             }
-            double price = plugin.getConfig().getDouble("sell-prices." + base + "." + mat.name(), 0.0);
+            String oreId = CustomItems.getId(item);
+            double price;
+            if (oreId != null) {
+                price = plugin.getConfig().getDouble("sell-prices." + base + "." + oreId, 0.0);
+            } else {
+                price = plugin.getConfig().getDouble("sell-prices." + base + "." + mat.name(), 0.0);
+            }
             total += price * item.getAmount();
             inventory.setItem(i, null);
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,5 +13,24 @@ database:
 
 sell-prices:
   world:
-    COAL_ORE: 1.0
-    IRON_ORE: 2.0
+    Hematite: 40.0
+    BlackSpinel: 70.0
+    BlackDiamond: 120.0
+    Magnetite: 50.0
+    Silver: 90.0
+    Osmium: 140.0
+    Azurite: 60.0
+    Tanzanite: 100.0
+    BlueSapphire: 150.0
+    Carnelian: 65.0
+    RedSpinel: 115.0
+    PigeonBloodRuby: 175.0
+    Pyrite: 75.0
+    YellowTopaz: 125.0
+    YellowSapphire: 180.0
+    Malachite: 90.0
+    Peridot: 130.0
+    TropicheEmerald: 200.0
+    Danburite: 100.0
+    Goshenite: 175.0
+    Cerussite: 300.0


### PR DESCRIPTION
## Summary
- List all custom ores in default config with price placeholders
- Track custom item IDs for ores
- Determine sale price using custom ore IDs when available

## Testing
- `mvn -q test` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*
- `mvn -q -o test` *(failed: Cannot access central in offline mode and the artifact maven-resources-plugin has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_6899a80c7ddc832a9f89bea10c00cb44