### PR TITLE
Add mine repair/enchant GUIs and ensure schematic folders exist

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/CrystalEnchantCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/CrystalEnchantCommand.java
@@ -63,7 +63,7 @@ public class CrystalEnchantCommand implements CommandExecutor, Listener {
     private void openMenu(Player player, ItemStack tool, int cost) {
         Inventory inv = Bukkit.createInventory(new EnchantMenu(tool, cost), 27, ChatColor.DARK_AQUA + "Crystal Enchants");
 
-        ItemStack filler = new ItemStack(Material.WHITE_STAINED_GLASS_PANE);
+        ItemStack filler = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
         ItemMeta fMeta = filler.getItemMeta();
         fMeta.setDisplayName(" ");
         filler.setItemMeta(fMeta);

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -10,6 +10,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.plugin.RegisteredServiceProvider;
+import java.io.File;
 
 import org.maks.mineSystemPlugin.command.LootCommand;
 import org.maks.mineSystemPlugin.command.MineCommand;
@@ -22,6 +23,7 @@ import org.maks.mineSystemPlugin.repository.LootRepository;
 import org.maks.mineSystemPlugin.repository.SpecialLootRepository;
 import org.maks.mineSystemPlugin.sphere.SphereManager;
 import org.maks.mineSystemPlugin.sphere.SphereListener;
+import org.maks.mineSystemPlugin.sphere.SphereType;
 import org.maks.mineSystemPlugin.listener.BlockBreakListener;
 import org.maks.mineSystemPlugin.listener.OreBreakListener;
 import org.maks.mineSystemPlugin.tool.ToolListener;
@@ -94,6 +96,7 @@ public final class MineSystemPlugin extends JavaPlugin {
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        createSchematicFolders();
         setupEconomy();
         database = new DatabaseManager(this);
         questRepository = new QuestRepository(database);
@@ -111,10 +114,10 @@ public final class MineSystemPlugin extends JavaPlugin {
         getCommand("specialloot").setExecutor(new SpecialLootCommand(this, specialLootRepository, specialLootManager));
 
         RepairCommand repairCommand = new RepairCommand(this);
-        getCommand("repair").setExecutor(repairCommand);
+        getCommand("mine_repair").setExecutor(repairCommand);
         registerListener(repairCommand);
         CrystalEnchantCommand ceCommand = new CrystalEnchantCommand(this);
-        getCommand("crystalenchant").setExecutor(ceCommand);
+        getCommand("mine_enchant").setExecutor(ceCommand);
         registerListener(ceCommand);
         getCommand("mine").setExecutor(new MineCommand(this, sphereManager));
         getCommand("spawnsphere").setExecutor(this);
@@ -124,6 +127,20 @@ public final class MineSystemPlugin extends JavaPlugin {
         registerListener(new BlockBreakListener(this));
         registerListener(new OreBreakListener(this));
         registerListener(new ToolListener(this));
+    }
+
+    /**
+     * Ensures that the schematic folder structure exists so that
+     * administrators can easily drop sphere schematics in the proper place.
+     */
+    private void createSchematicFolders() {
+        File base = new File(getDataFolder(), "schematics");
+        for (SphereType type : SphereType.values()) {
+            File folder = new File(base, type.getFolderName());
+            if (!folder.exists()) {
+                folder.mkdirs();
+            }
+        }
     }
 
     private void setupEconomy() {

--- a/src/main/java/org/maks/mineSystemPlugin/RepairCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/RepairCommand.java
@@ -60,7 +60,7 @@ public class RepairCommand implements CommandExecutor, Listener {
     private void openMenu(Player player, ItemStack tool, int cost) {
         Inventory inv = Bukkit.createInventory(new RepairMenu(tool, cost), 27, ChatColor.DARK_GREEN + "Repair Pickaxe");
 
-        ItemStack filler = new ItemStack(Material.WHITE_STAINED_GLASS_PANE);
+        ItemStack filler = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
         ItemMeta fMeta = filler.getItemMeta();
         fMeta.setDisplayName(" ");
         filler.setItemMeta(fMeta);

--- a/src/main/java/org/maks/mineSystemPlugin/item/CustomItems.java
+++ b/src/main/java/org/maks/mineSystemPlugin/item/CustomItems.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public final class CustomItems {
 
     private static final Map<String, ItemStack> ITEMS = new HashMap<>();
+    private static final Map<String, String> NAME_TO_ID = new HashMap<>();
 
     static {
         // Black Ore (Coal-based)
@@ -149,6 +150,9 @@ public final class CustomItems {
         }
         stack.setItemMeta(meta);
         ITEMS.put(id, stack);
+        if (meta.hasDisplayName()) {
+            NAME_TO_ID.put(meta.getDisplayName(), id);
+        }
     }
 
     /**
@@ -158,6 +162,20 @@ public final class CustomItems {
     public static ItemStack get(String id) {
         ItemStack stack = ITEMS.get(id);
         return stack != null ? stack.clone() : null;
+    }
+
+    /**
+     * Attempts to resolve the registered id for a given item instance.
+     */
+    public static String getId(ItemStack stack) {
+        if (stack == null) {
+            return null;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null && meta.hasDisplayName()) {
+            return NAME_TO_ID.get(meta.getDisplayName());
+        }
+        return null;
     }
 
     private CustomItems() {

--- a/src/main/java/org/maks/mineSystemPlugin/menu/SellMenu.java
+++ b/src/main/java/org/maks/mineSystemPlugin/menu/SellMenu.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.mineSystemPlugin.item.CustomItems;
 
 /**
  * GUI allowing players to sell mined ores for Vault currency.
@@ -112,7 +113,13 @@ public class SellMenu implements InventoryHolder, Listener {
             if (!isOre(mat)) {
                 continue;
             }
-            double price = plugin.getConfig().getDouble("sell-prices." + base + "." + mat.name(), 0.0);
+            String oreId = CustomItems.getId(item);
+            double price;
+            if (oreId != null) {
+                price = plugin.getConfig().getDouble("sell-prices." + base + "." + oreId, 0.0);
+            } else {
+                price = plugin.getConfig().getDouble("sell-prices." + base + "." + mat.name(), 0.0);
+            }
             total += price * item.getAmount();
             inventory.setItem(i, null);
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,5 +13,24 @@ database:
 
 sell-prices:
   world:
-    COAL_ORE: 1.0
-    IRON_ORE: 2.0
+    Hematite: 40.0
+    BlackSpinel: 70.0
+    BlackDiamond: 120.0
+    Magnetite: 50.0
+    Silver: 90.0
+    Osmium: 140.0
+    Azurite: 60.0
+    Tanzanite: 100.0
+    BlueSapphire: 150.0
+    Carnelian: 65.0
+    RedSpinel: 115.0
+    PigeonBloodRuby: 175.0
+    Pyrite: 75.0
+    YellowTopaz: 125.0
+    YellowSapphire: 180.0
+    Malachite: 90.0
+    Peridot: 130.0
+    TropicheEmerald: 200.0
+    Danburite: 100.0
+    Goshenite: 175.0
+    Cerussite: 300.0

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,12 +11,12 @@ commands:
   mine:
     description: Open the mine selection menu
     usage: /mine
-  repair:
+  mine_repair:
     description: Repair the item in your main hand using Crystals.
-    usage: /repair
-  crystalenchant:
+    usage: /mine_repair
+  mine_enchant:
     description: Enchants a pickaxe using crystals
-    usage: /crystalenchant
+    usage: /mine_enchant
 
   spawnsphere:
     description: Spawns a mining sphere for testing


### PR DESCRIPTION
## Summary
- Rename repair and enchant commands to `mine_repair` and `mine_enchant`
- Use black glass pane backgrounds in repair and enchant menus
- Register updated commands in plugin startup
- Populate configuration with pricing for all custom ores and resolve prices by ore ID
- Ensure schematic folders for each sphere type are created at startup

## Testing
- `mvn -q test` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899a80c7ddc832a9f89bea10c00cb44