### PR TITLE
Restrict ore mining to spheres and add crystal pouch integration

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/CrystalCurrency.java
+++ b/src/main/java/org/maks/mineSystemPlugin/CrystalCurrency.java
@@ -1,0 +1,98 @@
+package org.maks.mineSystemPlugin;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import org.maks.mineSystemPlugin.item.CustomItems;
+
+/**
+ * Utility class for handling Crystal currency stored in both player inventory
+ * and Ingredient Pouch.
+ */
+public final class CrystalCurrency {
+    private static final String ITEM_ID = "Crystal";
+    private static final String POUCH_ID = "crystal";
+
+    private static Object pouchAPI;
+    private static boolean apiAvailable = false;
+
+    static {
+        try {
+            Object pouchPlugin = Bukkit.getPluginManager().getPlugin("IngredientPouchPlugin");
+            if (pouchPlugin != null) {
+                pouchAPI = pouchPlugin.getClass().getMethod("getAPI").invoke(pouchPlugin);
+                apiAvailable = true;
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static boolean isCrystal(ItemStack stack) {
+        return stack != null && ITEM_ID.equals(CustomItems.getId(stack));
+    }
+
+    public static int countInventory(Player player) {
+        int total = 0;
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (isCrystal(item)) {
+                total += item.getAmount();
+            }
+        }
+        return total;
+    }
+
+    public static int countPouch(Player player) {
+        if (!apiAvailable) {
+            return 0;
+        }
+        try {
+            Object quantity = pouchAPI.getClass()
+                    .getMethod("getItemQuantity", String.class, String.class)
+                    .invoke(pouchAPI, player.getUniqueId().toString(), POUCH_ID);
+            return (Integer) quantity;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    public static boolean hasCrystals(Player player, int amount) {
+        return countInventory(player) + countPouch(player) >= amount;
+    }
+
+    public static boolean removeCrystals(Player player, int amount) {
+        if (!hasCrystals(player, amount)) {
+            return false;
+        }
+        int remaining = amount;
+        ItemStack[] contents = player.getInventory().getContents();
+        for (int i = 0; i < contents.length && remaining > 0; i++) {
+            ItemStack stack = contents[i];
+            if (isCrystal(stack)) {
+                int take = Math.min(stack.getAmount(), remaining);
+                stack.setAmount(stack.getAmount() - take);
+                remaining -= take;
+                if (stack.getAmount() <= 0) {
+                    contents[i] = null;
+                }
+            }
+        }
+        player.getInventory().setContents(contents);
+
+        if (remaining > 0 && apiAvailable) {
+            try {
+                Object success = pouchAPI.getClass()
+                        .getMethod("updateItemQuantity", String.class, String.class, int.class)
+                        .invoke(pouchAPI, player.getUniqueId().toString(), POUCH_ID, -remaining);
+                if (!(Boolean) success) {
+                    return false;
+                }
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private CrystalCurrency() {}
+}

--- a/src/main/java/org/maks/mineSystemPlugin/CrystalEnchantCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/CrystalEnchantCommand.java
@@ -20,11 +20,12 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
 
+import org.maks.mineSystemPlugin.CrystalCurrency;
+
 import org.maks.mineSystemPlugin.tool.CustomTool;
 
 public class CrystalEnchantCommand implements CommandExecutor, Listener {
 
-    private static final Material CURRENCY = Material.PRISMARINE_CRYSTALS;
     private final Random random = new Random();
     private final Plugin plugin;
 
@@ -149,21 +150,7 @@ public class CrystalEnchantCommand implements CommandExecutor, Listener {
     }
 
     private boolean removeCrystals(Player player, int amount) {
-        int remaining = amount;
-        ItemStack[] contents = player.getInventory().getContents();
-        for (int i = 0; i < contents.length; i++) {
-            ItemStack stack = contents[i];
-            if (stack == null || stack.getType() != CURRENCY) continue;
-            int take = Math.min(remaining, stack.getAmount());
-            stack.setAmount(stack.getAmount() - take);
-            remaining -= take;
-            if (stack.getAmount() == 0) {
-                contents[i] = null;
-            }
-            if (remaining <= 0) break;
-        }
-        player.getInventory().setContents(contents);
-        return remaining <= 0;
+        return CrystalCurrency.removeCrystals(player, amount);
     }
 
     private List<EnchantType> chooseEnchantments() {

--- a/src/main/java/org/maks/mineSystemPlugin/RepairCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/RepairCommand.java
@@ -22,6 +22,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.ChatColor;
+import org.maks.mineSystemPlugin.CrystalCurrency;
 
 /**
  * Command that repairs the item held in the player's main hand. The cost is
@@ -139,33 +140,11 @@ public class RepairCommand implements CommandExecutor, Listener {
     }
 
     private boolean hasCrystals(Player player, int amount) {
-        int total = 0;
-        for (ItemStack stack : player.getInventory().getContents()) {
-            if (stack != null && stack.getType() == Material.PRISMARINE_CRYSTALS) {
-                total += stack.getAmount();
-                if (total >= amount) {
-                    return true;
-                }
-            }
-        }
-        return total >= amount;
+        return CrystalCurrency.hasCrystals(player, amount);
     }
 
     private void removeCrystals(Player player, int amount) {
-        int remaining = amount;
-        ItemStack[] contents = player.getInventory().getContents();
-        for (int i = 0; i < contents.length && remaining > 0; i++) {
-            ItemStack stack = contents[i];
-            if (stack != null && stack.getType() == Material.PRISMARINE_CRYSTALS) {
-                int toRemove = Math.min(stack.getAmount(), remaining);
-                stack.setAmount(stack.getAmount() - toRemove);
-                remaining -= toRemove;
-                if (stack.getAmount() <= 0) {
-                    contents[i] = null;
-                }
-            }
-        }
-        player.getInventory().setContents(contents);
+        CrystalCurrency.removeCrystals(player, amount);
     }
 
     private void repairItem(ItemStack item) {

--- a/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
@@ -35,7 +35,7 @@ public class SpecialBlockListener implements Listener {
         switch (type) {
             case MOSS_BLOCK -> { requiredHits = 75; interval = 25; display = "Moss Block"; }
             case BONE_BLOCK -> { requiredHits = 100; interval = 25; display = "Bone Block"; }
-            case AMETHYST_BLOCK -> { requiredHits = 25; interval = 5; display = "Amethyst Block"; }
+            case AMETHYST_BLOCK -> { requiredHits = 25; interval = 5; display = "Crystals"; }
             default -> { return; }
         }
 
@@ -82,7 +82,7 @@ public class SpecialBlockListener implements Listener {
 
     private void showHologram(Location loc, String name, int remaining, int max) {
         ArmorStand stand = holograms.computeIfAbsent(loc, l ->
-                loc.getWorld().spawn(loc.clone().add(0.5, 0, 0.5), ArmorStand.class, as -> {
+                loc.getWorld().spawn(loc.clone().add(0.5, 1.2, 0.5), ArmorStand.class, as -> {
                     as.setInvisible(true);
                     as.setMarker(true);
                     as.setGravity(false);

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -41,6 +41,11 @@ public class BlockBreakListener implements Listener {
             return;
         }
 
+        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+            event.setCancelled(true);
+            return;
+        }
+
         Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
         Material oreType = block.getType();
@@ -51,6 +56,14 @@ public class BlockBreakListener implements Listener {
         plugin.getSphereManager().updateHologram(block.getLocation(), remaining);
 
         event.setCancelled(true);
+
+        // reduce durability on every hit
+        boolean broken = CustomTool.damage(tool, plugin);
+        if (broken) {
+            player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+        } else {
+            player.getInventory().setItemInMainHand(tool);
+        }
 
         if (remaining > 0) {
             return;
@@ -91,13 +104,6 @@ public class BlockBreakListener implements Listener {
                     block.getWorld().dropItemNaturally(block.getLocation(), reward.clone());
                 }
             }
-        }
-
-        boolean broken = CustomTool.damage(tool, plugin);
-        if (broken) {
-            player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
-        } else {
-            player.getInventory().setItemInMainHand(tool);
         }
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
@@ -38,6 +38,11 @@ public class OreBreakListener implements Listener {
             return;
         }
 
+        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+            event.setCancelled(true);
+            return;
+        }
+
         Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
         Collection<ItemStack> drops = block.getDrops(tool);

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -241,7 +241,7 @@ public class SphereManager {
                     origin.getBlockX() + vec.getX(),
                     origin.getBlockY() + vec.getY(),
                     origin.getBlockZ() + vec.getZ());
-            ArmorStand stand = world.spawn(blockLoc.clone().add(0.5, 0, 0.5), ArmorStand.class, as -> {
+            ArmorStand stand = world.spawn(blockLoc.clone().add(0.5, 1.2, 0.5), ArmorStand.class, as -> {
                 as.setInvisible(true);
                 as.setMarker(true);
                 as.setGravity(false);
@@ -427,5 +427,15 @@ public class SphereManager {
     public void removeAll() {
         Set<UUID> ids = new HashSet<>(active.keySet());
         ids.forEach(this::removeSphere);
+    }
+
+    public boolean isInsideSphere(Location loc) {
+        BlockVector3 vec = BlockVector3.at(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+        for (Sphere sphere : active.values()) {
+            if (sphere.getRegion().contains(vec)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- Block and ore breaks now require the player to be inside an active sphere
- Ore holograms spawn above ores for better visibility
- Introduced `CrystalCurrency` utility for crystal checks including IngredientPouch
- Updated repair and enchant commands to consume crystals from inventory or pouch
- Special block holograms for crystals, moss blocks, and bone blocks now appear above the block
- Amethyst block hologram renamed to **Crystals** for clearer naming
- Pickaxe durability now decreases on every custom ore hit, updating lore each swing

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899bbc05bcc832a9150f309e5c32555