### PR TITLE
Refresh inventory after pickaxe changes and durability loss

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/CrystalEnchantCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/CrystalEnchantCommand.java
@@ -115,6 +115,8 @@ public class CrystalEnchantCommand implements CommandExecutor, Listener {
             }
             List<EnchantType> enchants = chooseEnchantments();
             applyEnchantments(menu.tool, enchants);
+            player.getInventory().setItemInMainHand(menu.tool);
+            player.updateInventory(); // opcjonalnie, aby odświeżyć ekwipunek
             player.sendMessage(ChatColor.GREEN + "Pickaxe enchanted!");
             player.closeInventory();
         } else if (event.getSlot() == 22) {

--- a/src/main/java/org/maks/mineSystemPlugin/RepairCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/RepairCommand.java
@@ -195,6 +195,8 @@ public class RepairCommand implements CommandExecutor, Listener {
             }
             removeCrystals(player, menu.cost);
             repairItem(menu.tool);
+            player.getInventory().setItemInMainHand(menu.tool);
+            player.updateInventory(); // opcjonalnie, aby odświeżyć ekwipunek
             player.sendMessage(ChatColor.GREEN + "Item repaired for " + menu.cost + " Crystals.");
             player.closeInventory();
         } else if (event.getSlot() == 22) {

--- a/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
@@ -58,6 +58,7 @@ public class SpecialBlockListener implements Listener {
         } else {
             player.getInventory().setItemInMainHand(tool);
         }
+        player.updateInventory();
 
         if (hits < requiredHits) {
             if (hits % interval == 0) {

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -64,6 +64,7 @@ public class BlockBreakListener implements Listener {
         } else {
             player.getInventory().setItemInMainHand(tool);
         }
+        player.updateInventory();
 
         if (remaining > 0) {
             return;

--- a/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
@@ -62,6 +62,7 @@ public class ToolListener implements Listener {
         } else {
             player.getInventory().setItemInMainHand(tool);
         }
+        player.updateInventory();
     }
 
     private boolean canDestroy(ItemStack tool, Block block) {


### PR DESCRIPTION
## Summary
- Ensure repaired pickaxe is placed back into the player's main hand and inventory refreshes
- After enchanting, place updated pickaxe into player's main hand and refresh the inventory
- Refresh the player's inventory after each mining hit so pickaxe lore shows updated durability

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a221b0100832a91d769fd2cb3b391