### PR TITLE
Persist stamina and sphere data and spawn spheres remotely

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/CrystalEnchantCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/CrystalEnchantCommand.java
@@ -115,6 +115,8 @@ public class CrystalEnchantCommand implements CommandExecutor, Listener {
             }
             List<EnchantType> enchants = chooseEnchantments();
             applyEnchantments(menu.tool, enchants);
+            player.getInventory().setItemInMainHand(menu.tool);
+            player.updateInventory(); // opcjonalnie, aby odświeżyć ekwipunek
             player.sendMessage(ChatColor.GREEN + "Pickaxe enchanted!");
             player.closeInventory();
         } else if (event.getSlot() == 22) {

--- a/src/main/java/org/maks/mineSystemPlugin/RepairCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/RepairCommand.java
@@ -195,6 +195,8 @@ public class RepairCommand implements CommandExecutor, Listener {
             }
             removeCrystals(player, menu.cost);
             repairItem(menu.tool);
+            player.getInventory().setItemInMainHand(menu.tool);
+            player.updateInventory(); // opcjonalnie, aby odświeżyć ekwipunek
             player.sendMessage(ChatColor.GREEN + "Item repaired for " + menu.cost + " Crystals.");
             player.closeInventory();
         } else if (event.getSlot() == 22) {

--- a/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
@@ -58,6 +58,7 @@ public class SpecialBlockListener implements Listener {
         } else {
             player.getInventory().setItemInMainHand(tool);
         }
+        player.updateInventory();
 
         if (hits < requiredHits) {
             if (hits % interval == 0) {

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -64,6 +64,7 @@ public class BlockBreakListener implements Listener {
         } else {
             player.getInventory().setItemInMainHand(tool);
         }
+        player.updateInventory();
 
         if (remaining > 0) {
             return;

--- a/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
@@ -45,6 +45,14 @@ public class OreBreakListener implements Listener {
 
         Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
+        boolean broken = CustomTool.damage(tool, plugin);
+        if (broken) {
+            player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+        } else {
+            player.getInventory().setItemInMainHand(tool);
+        }
+        player.updateInventory();
+
         Collection<ItemStack> drops = block.getDrops(tool);
         event.setDropItems(false);
 

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -33,6 +33,8 @@ import org.maks.mineSystemPlugin.MineSystemPlugin;
 import org.maks.mineSystemPlugin.SpecialLootEntry;
 import org.maks.mineSystemPlugin.SpecialLootManager;
 import org.maks.mineSystemPlugin.stamina.StaminaManager;
+import org.maks.mineSystemPlugin.model.SphereData;
+import org.maks.mineSystemPlugin.repository.SphereRepository;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -116,14 +118,16 @@ public class SphereManager {
     private final Random random = new Random();
     private final int maxSpheres;
     private final StaminaManager stamina;
+    private final SphereRepository sphereRepository;
 
     private record HologramData(ArmorStand stand, String name, int max) {}
     private final Map<Location, HologramData> holograms = new HashMap<>();
     private final Map<Location, BukkitTask> hideTasks = new HashMap<>();
 
-    public SphereManager(Plugin plugin, StaminaManager stamina) {
+    public SphereManager(Plugin plugin, StaminaManager stamina, SphereRepository sphereRepository) {
         this.plugin = plugin;
         this.stamina = stamina;
+        this.sphereRepository = sphereRepository;
         this.maxSpheres = 20;
     }
 
@@ -196,16 +200,18 @@ public class SphereManager {
 
             populateChests(origin.getWorld(), region, type, schematic.getName());
 
-            Location tp = findSafeLocation(region, origin.getWorld());
-            if (tp != null) {
-                player.teleport(tp);
-            } else {
-                player.teleport(origin.clone().add(0.5, 1, 0.5));
-            }
-
             BukkitTask task = Bukkit.getScheduler().runTaskLater(plugin, () -> removeSphere(player.getUniqueId()), LIFE_TIME_TICKS);
             Sphere sphere = new Sphere(type, region, task, origin.getWorld(), origin, holograms);
             active.put(player.getUniqueId(), sphere);
+            sphereRepository.save(new SphereData(player.getUniqueId(), type.name(), System.currentTimeMillis()));
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                Location tp = findSafeLocation(region, origin.getWorld());
+                if (tp != null) {
+                    player.teleport(tp);
+                } else {
+                    player.teleport(origin.clone().add(0.5, 1, 0.5));
+                }
+            }, 40L);
             Bukkit.getScheduler().runTaskLater(plugin,
                     () -> spawnConfiguredMobs(schematic.getName(), region, origin.getWorld()), 20L);
             return true;
@@ -213,6 +219,15 @@ public class SphereManager {
             player.sendMessage("Failed to create sphere");
             return false;
         }
+    }
+
+    private Location randomFarLocation(World world) {
+        int distance = 10000 + random.nextInt(10001);
+        double angle = random.nextDouble() * 2 * Math.PI;
+        int x = (int) (Math.cos(angle) * distance);
+        int z = (int) (Math.sin(angle) * distance);
+        int y = world.getMaxHeight() / 2;
+        return new Location(world, x, y, z);
     }
 
     private Map<BlockVector3, OreVariant> replacePlaceholders(Clipboard clipboard, boolean premium) {
@@ -328,15 +343,6 @@ public class SphereManager {
         return null;
     }
 
-    private Location randomFarLocation(World world) {
-        int distance = 10000 + random.nextInt(10001); // 10k-20k blocks from spawn
-        double angle = random.nextDouble() * 2 * Math.PI;
-        int x = (int) (Math.cos(angle) * distance);
-        int z = (int) (Math.sin(angle) * distance);
-        int y = world.getMaxHeight() / 2;
-        return new Location(world, x, y, z);
-    }
-
     private void spawnConfiguredMobs(String schematic, Region region, World world) {
         List<Map<?, ?>> entries = ((JavaPlugin) plugin).getConfig().getMapList("mobs." + schematic);
         for (Map<?, ?> entry : entries) {
@@ -399,6 +405,7 @@ public class SphereManager {
             }
             sphere.remove();
             clearHolograms(sphere);
+            sphereRepository.save(new SphereData(uuid, sphere.getType().name(), 0L));
         }
     }
 

--- a/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
@@ -62,6 +62,7 @@ public class ToolListener implements Listener {
         } else {
             player.getInventory().setItemInMainHand(tool);
         }
+        player.updateInventory();
     }
 
     private boolean canDestroy(ItemStack tool, Block block) {


### PR DESCRIPTION
## Summary
- Damage tools and refresh inventory on ore break so pickaxe lore updates immediately
- Spawn spheres far from players, record start time, and teleport players to a safe spot after a short delay
- Persist player stamina and sphere data to the database and flush on resets or shutdown

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a221b0100832a91d769fd2cb3b391