### PR TITLE
Fix ore hologram lookup and remove spheres on player death

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -217,7 +217,8 @@ public final class MineSystemPlugin extends JavaPlugin {
     }
 
     public String resolveOreId(Block block) {
-        return blockOreTypes.computeIfAbsent(block.getLocation(), loc -> randomOreFor(block.getType()));
+        Location loc = block.getLocation().toBlockLocation();
+        return blockOreTypes.computeIfAbsent(loc, l -> randomOreFor(block.getType()));
     }
 
     private String randomOreFor(Material material) {
@@ -230,6 +231,7 @@ public final class MineSystemPlugin extends JavaPlugin {
     }
 
     public int decrementBlockHits(Location location, String oreId) {
+        location = location.toBlockLocation();
         int required = ORE_DURABILITY.getOrDefault(oreId, 1);
         int hits = blockHits.getOrDefault(location, 0) + 1;
         if (hits >= required) {
@@ -255,10 +257,11 @@ public final class MineSystemPlugin extends JavaPlugin {
      * @param oreId    internal ore identifier (e.g. "BlackSpinel")
      */
     public void registerOre(Location location, String oreId) {
-        blockOreTypes.put(location, oreId);
-        blockHits.remove(location);
+        Location loc = location.toBlockLocation();
+        blockOreTypes.put(loc, oreId);
+        blockHits.remove(loc);
         getLogger().info(String.format("Registered ore %s at %d %d %d", oreId,
-                location.getBlockX(), location.getBlockY(), location.getBlockZ()));
+                loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
 
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -51,12 +51,13 @@ public class BlockBreakListener implements Listener {
         Material oreType = block.getType();
 
         String oreId = plugin.resolveOreId(block);
-        int remaining = plugin.decrementBlockHits(block.getLocation(), oreId);
+        var loc = block.getLocation().toBlockLocation();
+        int remaining = plugin.decrementBlockHits(loc, oreId);
         plugin.getLogger().info(String.format(
                 "Block hit %s (%s) at %d %d %d, remaining=%d", oreType, oreId,
                 block.getX(), block.getY(), block.getZ(), remaining));
 
-        plugin.getSphereManager().updateHologram(block.getLocation(), remaining);
+        plugin.getSphereManager().updateHologram(loc, remaining);
 
         event.setCancelled(true);
 

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereListener.java
@@ -2,6 +2,7 @@ package org.maks.mineSystemPlugin.sphere;
 
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 /**
@@ -18,5 +19,12 @@ public class SphereListener implements Listener {
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
         manager.onPlayerQuit(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        if (manager.isInsideSphere(event.getEntity().getLocation())) {
+            manager.removeSphereOnDeath(event.getEntity());
+        }
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -322,7 +322,7 @@ public class SphereManager {
         for (Map.Entry<BlockVector3, OreVariant> entry : variants.entrySet()) {
             BlockVector3 vec = entry.getKey().add(shift);
             OreVariant data = entry.getValue();
-            Location blockLoc = new Location(world, vec.getX(), vec.getY(), vec.getZ());
+            Location blockLoc = new Location(world, vec.getX(), vec.getY(), vec.getZ()).toBlockLocation();
             String display = addSpaces(data.name());
             ArmorStand stand = world.spawn(blockLoc.clone().add(0.5, 1.2, 0.5), ArmorStand.class, as -> {
                 as.setInvisible(true);
@@ -375,6 +375,7 @@ public class SphereManager {
     }
 
     public void updateHologram(Location loc, int remaining) {
+        loc = loc.toBlockLocation();
         HologramData data = holograms.get(loc);
         if (data == null) {
             return;
@@ -456,6 +457,10 @@ public class SphereManager {
 
     public void removeSphere(Player player) {
         removeSphere(player.getUniqueId(), player);
+    }
+
+    public void removeSphereOnDeath(Player player) {
+        removeSphere(player.getUniqueId(), null);
     }
 
     private void removeSphere(UUID uuid, Player player) {


### PR DESCRIPTION
## Summary
- normalize block locations for ore holograms to ensure stands are found and updated
- clear a player's sphere when they die inside it to avoid late teleports

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689aeb058d84832aacf4f645e0374fa8