### PR TITLE
Fix hologram handling for ores

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -83,6 +83,16 @@ public final class MineSystemPlugin extends JavaPlugin {
             Map.entry("Cerussite", 300)
     );
 
+    /**
+     * Returns the configured durability for a given ore identifier.
+     *
+     * @param oreId internal ore name
+     * @return number of required hits before the ore breaks
+     */
+    public int getOreDurability(String oreId) {
+        return ORE_DURABILITY.getOrDefault(oreId, 1);
+    }
+
     private static final Map<Material, List<String>> ORE_ITEM_MAP = Map.of(
             Material.COAL_ORE, List.of("Hematite", "BlackSpinel", "BlackDiamond"),
             Material.IRON_ORE, List.of("Magnetite", "Silver", "Osmium"),

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -57,7 +57,7 @@ public class BlockBreakListener implements Listener {
                 "Block hit %s (%s) at %d %d %d, remaining=%d", oreType, oreId,
                 block.getX(), block.getY(), block.getZ(), remaining));
 
-        plugin.getSphereManager().updateHologram(loc, remaining);
+        plugin.getSphereManager().updateHologram(loc, oreId, remaining);
 
         event.setCancelled(true);
 

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -374,11 +374,20 @@ public class SphereManager {
         return sb.toString();
     }
 
-    public void updateHologram(Location loc, int remaining) {
+    public void updateHologram(Location loc, String oreId, int remaining) {
         loc = loc.toBlockLocation();
         HologramData data = holograms.get(loc);
         if (data == null) {
-            return;
+            MineSystemPlugin pluginImpl = (MineSystemPlugin) plugin;
+            int max = pluginImpl.getOreDurability(oreId);
+            String display = addSpaces(oreId);
+            ArmorStand stand = loc.getWorld().spawn(loc.clone().add(0.5, 1.2, 0.5), ArmorStand.class, as -> {
+                as.setInvisible(true);
+                as.setMarker(true);
+                as.setGravity(false);
+            });
+            data = new HologramData(stand, display, max);
+            holograms.put(loc, data);
         }
         if (remaining <= 0) {
             BukkitTask task = hideTasks.remove(loc);


### PR DESCRIPTION
## Summary
- spawn missing ore holograms on first hit and show remaining durability
- expose ore durability lookup used by hologram updates
- pass ore identifier when updating holograms

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689afafc3aa8832a9d34db3b2cb3b85a