### PR TITLE
Count hits toward ore rewards

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
@@ -30,8 +30,11 @@ public class SpecialBlockListener implements Listener {
         Block block = event.getBlock();
         Material type = block.getType();
 
+        Player player = event.getPlayer();
+        boolean bypass = player.isOp() || player.hasPermission("minesystem.admin");
+
         Location loc = block.getLocation();
-        if (!plugin.getSphereManager().isInsideSphere(loc)) {
+        if (!bypass && !plugin.getSphereManager().isInsideSphere(loc)) {
             event.setCancelled(true);
             return;
         }

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -33,12 +33,13 @@ public class BlockBreakListener implements Listener {
             return;
         }
 
-        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+        Player player = event.getPlayer();
+        boolean bypass = player.isOp() || player.hasPermission("minesystem.admin");
+        if (!bypass && !plugin.getSphereManager().isInsideSphere(block.getLocation())) {
             event.setCancelled(true);
             return;
         }
 
-        Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
         Material oreType = block.getType();
 
@@ -49,6 +50,11 @@ public class BlockBreakListener implements Listener {
         plugin.getSphereManager().updateHologram(loc, oreId, remaining);
 
         event.setCancelled(true);
+
+        int total = plugin.incrementOreCount(player.getUniqueId());
+        if (total % 20 == 0) {
+            plugin.dropRandomOreReward(player, block.getLocation());
+        }
 
         if (remaining > 0) {
             return;
@@ -78,11 +84,5 @@ public class BlockBreakListener implements Listener {
         int amount = drop == null ? 0 : (duplicate ? drop.getAmount() * 2 : drop.getAmount());
         int pickaxeLevel = CustomTool.getToolLevel(tool);
         Bukkit.getPluginManager().callEvent(new OreMinedEvent(player, oreType, amount, pickaxeLevel));
-
-        int total = plugin.incrementOreCount(player.getUniqueId());
-        if (total % 20 == 0) {
-            plugin.dropRandomOreReward(player, block.getLocation());
-
-        }
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
@@ -34,12 +34,13 @@ public class OreBreakListener implements Listener {
             return; // handled by BlockBreakListener
         }
 
-        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+        Player player = event.getPlayer();
+        boolean bypass = player.isOp() || player.hasPermission("minesystem.admin");
+        if (!bypass && !plugin.getSphereManager().isInsideSphere(block.getLocation())) {
             event.setCancelled(true);
             return;
         }
 
-        Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
 
         Collection<ItemStack> drops = block.getDrops(tool);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,7 @@ mobs:
       amount: 3
 
 sell-prices:
-  world: # nazwa �wiata
+  world: # nazwa świata
     Hematite: 1000000
     BlackSpinel: 1750000
     BlackDiamond: 3000000

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,3 +32,7 @@ commands:
     description: Check your stamina
     usage: /stamin
     permission: minesystemplugin.mine
+permissions:
+  minesystem.admin:
+    description: Bypass mining restrictions
+    default: op


### PR DESCRIPTION
## Summary
- Drop bonus ore items every 20 custom-ore hits instead of waiting for complete breaks
- Allow ops or players with `minesystem.admin` to ignore sphere mining restrictions
- Declare `minesystem.admin` permission in plugin.yml

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b181d6090832a95882f1fb81f48d6