### PR TITLE
Count hits toward ore rewards and allow normal mining outside spheres

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -28,6 +28,7 @@ import org.maks.mineSystemPlugin.sphere.SphereManager;
 import org.maks.mineSystemPlugin.sphere.SphereListener;
 import org.maks.mineSystemPlugin.sphere.SphereType;
 import org.maks.mineSystemPlugin.listener.BlockBreakListener;
+import org.maks.mineSystemPlugin.listener.BlockPlaceListener;
 import org.maks.mineSystemPlugin.listener.OreBreakListener;
 import org.maks.mineSystemPlugin.tool.ToolListener;
 import org.maks.mineSystemPlugin.SpecialBlockListener;
@@ -40,10 +41,12 @@ import java.time.Duration;
 import org.maks.mineSystemPlugin.sphere.Tier;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
 
 import org.bukkit.inventory.ItemStack;
 import org.maks.mineSystemPlugin.item.CustomItems;
@@ -112,6 +115,7 @@ public final class MineSystemPlugin extends JavaPlugin {
     private final Map<Location, Integer> blockHits = new HashMap<>();
     private final Map<Location, String> blockOreTypes = new HashMap<>();
     private final Map<UUID, Integer> oreCounts = new HashMap<>();
+    private final Set<Location> placedOres = new HashSet<>();
     private final Random random = new Random();
 
     private static final List<String> BONUS_ITEMS = List.of("ore_I", "ore_II", "ore_III");
@@ -151,6 +155,7 @@ public final class MineSystemPlugin extends JavaPlugin {
         registerListener(new SpecialBlockListener(this));
         registerListener(new SphereListener(sphereManager));
         registerListener(new BlockBreakListener(this));
+        registerListener(new BlockPlaceListener(this));
         registerListener(new OreBreakListener(this));
         registerListener(new ToolListener(this));
     }
@@ -271,6 +276,14 @@ public final class MineSystemPlugin extends JavaPlugin {
 
     public void resetOreCount(UUID uuid) {
         oreCounts.remove(uuid);
+    }
+
+    public void markPlayerPlaced(Location location) {
+        placedOres.add(location.toBlockLocation());
+    }
+
+    public boolean consumePlayerPlaced(Location location) {
+        return placedOres.remove(location.toBlockLocation());
     }
 
     public void dropRandomOreReward(Player player, Location loc) {

--- a/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
@@ -29,12 +29,15 @@ public class SpecialBlockListener implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         Block block = event.getBlock();
         Material type = block.getType();
-
         Location loc = block.getLocation();
+
+        // Outside mining spheres the plugin should not interfere –
+        // let the block break normally without any custom handling.
         if (!plugin.getSphereManager().isInsideSphere(loc)) {
-            event.setCancelled(true);
             return;
         }
+
+        Player player = event.getPlayer();
 
         int requiredHits;
         int interval;
@@ -75,7 +78,6 @@ public class SpecialBlockListener implements Listener {
         World world = block.getWorld();
 
         // handle duplication enchant
-        Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
         int dupLevel = CustomTool.getDuplicateLevel(tool, plugin);
         double chance = switch (dupLevel) {

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -33,12 +33,17 @@ public class BlockBreakListener implements Listener {
             return;
         }
 
-        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
-            event.setCancelled(true);
+        if (plugin.consumePlayerPlaced(block.getLocation())) {
             return;
         }
 
         Player player = event.getPlayer();
+        boolean bypass = player.isOp() || player.hasPermission("minesystem.admin");
+        if (!bypass && !plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+            event.setCancelled(true);
+            return;
+        }
+
         ItemStack tool = player.getInventory().getItemInMainHand();
         Material oreType = block.getType();
 
@@ -49,6 +54,11 @@ public class BlockBreakListener implements Listener {
         plugin.getSphereManager().updateHologram(loc, oreId, remaining);
 
         event.setCancelled(true);
+
+        int total = plugin.incrementOreCount(player.getUniqueId());
+        if (total % 20 == 0) {
+            plugin.dropRandomOreReward(player, block.getLocation());
+        }
 
         if (remaining > 0) {
             return;
@@ -78,11 +88,5 @@ public class BlockBreakListener implements Listener {
         int amount = drop == null ? 0 : (duplicate ? drop.getAmount() * 2 : drop.getAmount());
         int pickaxeLevel = CustomTool.getToolLevel(tool);
         Bukkit.getPluginManager().callEvent(new OreMinedEvent(player, oreType, amount, pickaxeLevel));
-
-        int total = plugin.incrementOreCount(player.getUniqueId());
-        if (total % 20 == 0) {
-            plugin.dropRandomOreReward(player, block.getLocation());
-
-        }
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockPlaceListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockPlaceListener.java
@@ -1,0 +1,33 @@
+package org.maks.mineSystemPlugin.listener;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+/**
+ * Marks ore blocks placed outside of mining spheres so they can be broken
+ * normally without triggering custom mining restrictions.
+ */
+public class BlockPlaceListener implements Listener {
+
+    private final MineSystemPlugin plugin;
+
+    public BlockPlaceListener(MineSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        Block block = event.getBlockPlaced();
+        Material type = block.getType();
+        if (!type.name().endsWith("_ORE")) {
+            return;
+        }
+        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+            plugin.markPlayerPlaced(block.getLocation());
+        }
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
@@ -30,16 +30,21 @@ public class OreBreakListener implements Listener {
             return;
         }
 
+        if (plugin.consumePlayerPlaced(block.getLocation())) {
+            return;
+        }
+
         if (plugin.isCustomOre(type)) {
             return; // handled by BlockBreakListener
         }
 
-        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+        Player player = event.getPlayer();
+        boolean bypass = player.isOp() || player.hasPermission("minesystem.admin");
+        if (!bypass && !plugin.getSphereManager().isInsideSphere(block.getLocation())) {
             event.setCancelled(true);
             return;
         }
 
-        Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
 
         Collection<ItemStack> drops = block.getDrops(tool);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,7 @@ mobs:
       amount: 3
 
 sell-prices:
-  world: # nazwa �wiata
+  world: # nazwa świata
     Hematite: 1000000
     BlackSpinel: 1750000
     BlackDiamond: 3000000

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,3 +32,7 @@ commands:
     description: Check your stamina
     usage: /stamin
     permission: minesystemplugin.mine
+permissions:
+  minesystem.admin:
+    description: Bypass mining restrictions
+    default: op


### PR DESCRIPTION
## Summary
- Drop bonus ore items every 20 custom-ore hits instead of waiting for complete breaks
- Allow ops or players with `minesystem.admin` to ignore sphere mining restrictions
- Let ores placed outside spheres be mined normally by tracking and skipping custom logic
- Declare `minesystem.admin` permission in plugin.yml
- Ignore special-block logic outside spheres so crystals, moss blocks, and bone blocks break normally

## Testing
- `mvn -q test` *(fails: PluginResolutionException – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b181d6090832a95882f1fb81f48d6