### PR TITLE
Count hits toward ore rewards, allow normal mining outside spheres, fine-tune loot chances, and preserve loot metadata

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/ItemSerializer.java
+++ b/src/main/java/org/maks/mineSystemPlugin/ItemSerializer.java
@@ -1,0 +1,44 @@
+package org.maks.mineSystemPlugin;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+/**
+ * Utility for serializing ItemStacks to Base64 strings and back, preserving all metadata.
+ */
+public final class ItemSerializer {
+    private ItemSerializer() {}
+
+    public static String serialize(ItemStack item) {
+        if (item == null) {
+            return "";
+        }
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream)) {
+            dataOutput.writeObject(item);
+            return Base64.getEncoder().encodeToString(outputStream.toByteArray());
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+
+    public static ItemStack deserialize(String data) {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(data));
+             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream)) {
+            return (ItemStack) dataInput.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/LootEntry.java
+++ b/src/main/java/org/maks/mineSystemPlugin/LootEntry.java
@@ -1,0 +1,8 @@
+package org.maks.mineSystemPlugin;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Represents a loot item with its chance in percent.
+ */
+public record LootEntry(ItemStack item, int chance) {}

--- a/src/main/java/org/maks/mineSystemPlugin/LootManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/LootManager.java
@@ -1,23 +1,25 @@
 package org.maks.mineSystemPlugin;
 
-import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 /**
  * Handles randomisation logic for loot rolls.
  */
 public class LootManager {
     private final Random random = new Random();
-    private Map<Material, Integer> probabilities = new HashMap<>();
+    private List<LootEntry> entries = new ArrayList<>();
 
     /**
-     * Updates internal probabilities map. Key is item material, value is chance in percent.
+     * Updates internal loot entries.
      */
-    public void setProbabilities(Map<Material, Integer> probabilities) {
-        this.probabilities = probabilities;
+    public void setEntries(List<LootEntry> entries) {
+        this.entries = entries;
     }
 
     // Probability distribution for number of rewards in a chest, index 0 corresponds to count=1
@@ -44,25 +46,25 @@ public class LootManager {
     }
 
     /**
-     * Selects an item material from configured probabilities.
+     * Selects an item from configured probabilities.
      */
-    public Material rollItem() {
-        if (probabilities.isEmpty()) {
+    public ItemStack rollItem() {
+        if (entries.isEmpty()) {
             return null;
         }
-        int total = probabilities.values().stream().mapToInt(Integer::intValue).sum();
+        int total = entries.stream().mapToInt(LootEntry::chance).sum();
         if (total <= 0) {
             return null;
         }
         int r = random.nextInt(total);
         int cumulative = 0;
-        for (Map.Entry<Material, Integer> entry : probabilities.entrySet()) {
-            cumulative += entry.getValue();
+        for (LootEntry entry : entries) {
+            cumulative += entry.chance();
             if (r < cumulative) {
-                return entry.getKey();
+                return entry.item().clone();
             }
         }
-        return probabilities.keySet().iterator().next();
+        return entries.get(0).item().clone();
     }
 
     /**
@@ -77,9 +79,9 @@ public class LootManager {
         }
         Collections.shuffle(slots, random);
         for (int i = 0; i < count && i < slots.size(); i++) {
-            Material material = rollItem();
-            if (material != null) {
-                inventory.setItem(slots.get(i), new ItemStack(material));
+            ItemStack item = rollItem();
+            if (item != null) {
+                inventory.setItem(slots.get(i), item);
             }
         }
     }

--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -28,6 +28,7 @@ import org.maks.mineSystemPlugin.sphere.SphereManager;
 import org.maks.mineSystemPlugin.sphere.SphereListener;
 import org.maks.mineSystemPlugin.sphere.SphereType;
 import org.maks.mineSystemPlugin.listener.BlockBreakListener;
+import org.maks.mineSystemPlugin.listener.BlockPlaceListener;
 import org.maks.mineSystemPlugin.listener.OreBreakListener;
 import org.maks.mineSystemPlugin.tool.ToolListener;
 import org.maks.mineSystemPlugin.SpecialBlockListener;
@@ -40,10 +41,12 @@ import java.time.Duration;
 import org.maks.mineSystemPlugin.sphere.Tier;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
 
 import org.bukkit.inventory.ItemStack;
 import org.maks.mineSystemPlugin.item.CustomItems;
@@ -112,6 +115,7 @@ public final class MineSystemPlugin extends JavaPlugin {
     private final Map<Location, Integer> blockHits = new HashMap<>();
     private final Map<Location, String> blockOreTypes = new HashMap<>();
     private final Map<UUID, Integer> oreCounts = new HashMap<>();
+    private final Set<Location> placedOres = new HashSet<>();
     private final Random random = new Random();
 
     private static final List<String> BONUS_ITEMS = List.of("ore_I", "ore_II", "ore_III");
@@ -129,7 +133,7 @@ public final class MineSystemPlugin extends JavaPlugin {
         staminaManager = new StaminaManager(this, 100, Duration.ofHours(12), questRepository, playerRepository);
         lootManager = new LootManager();
         lootRepository = new LootRepository(database);
-        lootManager.setProbabilities(lootRepository.load().join());
+        lootManager.setEntries(lootRepository.load().join());
         specialLootManager = new SpecialLootManager();
         specialLootRepository = new SpecialLootRepository(database);
         specialLootRepository.loadAll().join().forEach(specialLootManager::setLoot);
@@ -151,6 +155,7 @@ public final class MineSystemPlugin extends JavaPlugin {
         registerListener(new SpecialBlockListener(this));
         registerListener(new SphereListener(sphereManager));
         registerListener(new BlockBreakListener(this));
+        registerListener(new BlockPlaceListener(this));
         registerListener(new OreBreakListener(this));
         registerListener(new ToolListener(this));
     }
@@ -271,6 +276,14 @@ public final class MineSystemPlugin extends JavaPlugin {
 
     public void resetOreCount(UUID uuid) {
         oreCounts.remove(uuid);
+    }
+
+    public void markPlayerPlaced(Location location) {
+        placedOres.add(location.toBlockLocation());
+    }
+
+    public boolean consumePlayerPlaced(Location location) {
+        return placedOres.remove(location.toBlockLocation());
     }
 
     public void dropRandomOreReward(Player player, Location loc) {

--- a/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/SpecialBlockListener.java
@@ -29,12 +29,15 @@ public class SpecialBlockListener implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         Block block = event.getBlock();
         Material type = block.getType();
-
         Location loc = block.getLocation();
+
+        // Outside mining spheres the plugin should not interfere –
+        // let the block break normally without any custom handling.
         if (!plugin.getSphereManager().isInsideSphere(loc)) {
-            event.setCancelled(true);
             return;
         }
+
+        Player player = event.getPlayer();
 
         int requiredHits;
         int interval;
@@ -75,7 +78,6 @@ public class SpecialBlockListener implements Listener {
         World world = block.getWorld();
 
         // handle duplication enchant
-        Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
         int dupLevel = CustomTool.getDuplicateLevel(tool, plugin);
         double chance = switch (dupLevel) {

--- a/src/main/java/org/maks/mineSystemPlugin/SpecialLootEntry.java
+++ b/src/main/java/org/maks/mineSystemPlugin/SpecialLootEntry.java
@@ -1,6 +1,8 @@
 package org.maks.mineSystemPlugin;
 
+import org.bukkit.inventory.ItemStack;
+
 /**
- * Represents a single loot entry with a fixed amount and chance in percent.
+ * Represents a single loot entry with a fixed chance in percent and full item metadata.
  */
-public record SpecialLootEntry(int amount, int chance) {}
+public record SpecialLootEntry(ItemStack item, int chance) {}

--- a/src/main/java/org/maks/mineSystemPlugin/SpecialLootManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/SpecialLootManager.java
@@ -1,23 +1,27 @@
 package org.maks.mineSystemPlugin;
 
-import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
 /**
  * Holds fixed loot tables per schematic for special zones.
  */
 public class SpecialLootManager {
-    private final Map<String, Map<Material, SpecialLootEntry>> tables = new HashMap<>();
+    private final Map<String, List<SpecialLootEntry>> tables = new HashMap<>();
     private final Random random = new Random();
 
-    public void setLoot(String schematic, Map<Material, SpecialLootEntry> items) {
+    public void setLoot(String schematic, List<SpecialLootEntry> items) {
         tables.put(schematic, items);
     }
 
-    public Map<Material, SpecialLootEntry> getLoot(String schematic) {
+    public List<SpecialLootEntry> getLoot(String schematic) {
         return tables.get(schematic);
     }
 
@@ -25,7 +29,7 @@ public class SpecialLootManager {
      * Fills inventory with items according to configured chances for the given schematic.
      */
     public void fillInventory(String schematic, Inventory inventory) {
-        Map<Material, SpecialLootEntry> items = tables.get(schematic);
+        List<SpecialLootEntry> items = tables.get(schematic);
         if (items == null || items.isEmpty()) {
             return;
         }
@@ -35,13 +39,12 @@ public class SpecialLootManager {
         }
         Collections.shuffle(slots, random);
         int i = 0;
-        for (Map.Entry<Material, SpecialLootEntry> entry : items.entrySet()) {
+        for (SpecialLootEntry entry : items) {
             if (i >= slots.size()) {
                 break;
             }
-            SpecialLootEntry spec = entry.getValue();
-            if (random.nextInt(100) < spec.chance()) {
-                inventory.setItem(slots.get(i), new ItemStack(entry.getKey(), spec.amount()));
+            if (random.nextInt(100) < entry.chance()) {
+                inventory.setItem(slots.get(i), entry.item().clone());
                 i++;
             }
         }

--- a/src/main/java/org/maks/mineSystemPlugin/database/DatabaseManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/database/DatabaseManager.java
@@ -47,12 +47,35 @@ public class DatabaseManager {
             statement.executeUpdate("CREATE TABLE IF NOT EXISTS pickaxes (uuid VARCHAR(36) PRIMARY KEY, material VARCHAR(32), durability INT, enchants TEXT)");
             statement.executeUpdate("CREATE TABLE IF NOT EXISTS quests (uuid VARCHAR(36) PRIMARY KEY, progress INT)");
             statement.executeUpdate("CREATE TABLE IF NOT EXISTS spheres (uuid VARCHAR(36) PRIMARY KEY, type VARCHAR(32), start_time BIGINT)");
-            statement.executeUpdate("CREATE TABLE IF NOT EXISTS loot_items (material VARCHAR(64) PRIMARY KEY, chance INT)");
-            statement.executeUpdate("CREATE TABLE IF NOT EXISTS special_loot (schematic VARCHAR(64), material VARCHAR(64), amount INT, chance INT, PRIMARY KEY(schematic, material))");
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS loot_items (id INT AUTO_INCREMENT PRIMARY KEY, item TEXT, chance INT)");
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS special_loot (id INT AUTO_INCREMENT PRIMARY KEY, schematic VARCHAR(64), item TEXT, chance INT)");
             try {
-                statement.executeUpdate("ALTER TABLE special_loot ADD COLUMN chance INT DEFAULT 0");
+                statement.executeUpdate("ALTER TABLE loot_items ADD COLUMN item TEXT");
             } catch (SQLException ignore) {
-                // column already exists
+            }
+            try {
+                statement.executeUpdate("ALTER TABLE loot_items ADD COLUMN id INT AUTO_INCREMENT PRIMARY KEY");
+            } catch (SQLException ignore) {
+            }
+            try {
+                statement.executeUpdate("ALTER TABLE loot_items DROP COLUMN material");
+            } catch (SQLException ignore) {
+            }
+            try {
+                statement.executeUpdate("ALTER TABLE special_loot ADD COLUMN item TEXT");
+            } catch (SQLException ignore) {
+            }
+            try {
+                statement.executeUpdate("ALTER TABLE special_loot ADD COLUMN id INT AUTO_INCREMENT PRIMARY KEY");
+            } catch (SQLException ignore) {
+            }
+            try {
+                statement.executeUpdate("ALTER TABLE special_loot DROP COLUMN material");
+            } catch (SQLException ignore) {
+            }
+            try {
+                statement.executeUpdate("ALTER TABLE special_loot DROP COLUMN amount");
+            } catch (SQLException ignore) {
             }
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockBreakListener.java
@@ -33,12 +33,17 @@ public class BlockBreakListener implements Listener {
             return;
         }
 
-        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
-            event.setCancelled(true);
+        if (plugin.consumePlayerPlaced(block.getLocation())) {
             return;
         }
 
         Player player = event.getPlayer();
+        boolean bypass = player.isOp() || player.hasPermission("minesystem.admin");
+        if (!bypass && !plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+            event.setCancelled(true);
+            return;
+        }
+
         ItemStack tool = player.getInventory().getItemInMainHand();
         Material oreType = block.getType();
 
@@ -49,6 +54,11 @@ public class BlockBreakListener implements Listener {
         plugin.getSphereManager().updateHologram(loc, oreId, remaining);
 
         event.setCancelled(true);
+
+        int total = plugin.incrementOreCount(player.getUniqueId());
+        if (total % 20 == 0) {
+            plugin.dropRandomOreReward(player, block.getLocation());
+        }
 
         if (remaining > 0) {
             return;
@@ -78,11 +88,5 @@ public class BlockBreakListener implements Listener {
         int amount = drop == null ? 0 : (duplicate ? drop.getAmount() * 2 : drop.getAmount());
         int pickaxeLevel = CustomTool.getToolLevel(tool);
         Bukkit.getPluginManager().callEvent(new OreMinedEvent(player, oreType, amount, pickaxeLevel));
-
-        int total = plugin.incrementOreCount(player.getUniqueId());
-        if (total % 20 == 0) {
-            plugin.dropRandomOreReward(player, block.getLocation());
-
-        }
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/listener/BlockPlaceListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/BlockPlaceListener.java
@@ -1,0 +1,33 @@
+package org.maks.mineSystemPlugin.listener;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.maks.mineSystemPlugin.MineSystemPlugin;
+
+/**
+ * Marks ore blocks placed outside of mining spheres so they can be broken
+ * normally without triggering custom mining restrictions.
+ */
+public class BlockPlaceListener implements Listener {
+
+    private final MineSystemPlugin plugin;
+
+    public BlockPlaceListener(MineSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        Block block = event.getBlockPlaced();
+        Material type = block.getType();
+        if (!type.name().endsWith("_ORE")) {
+            return;
+        }
+        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+            plugin.markPlayerPlaced(block.getLocation());
+        }
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/OreBreakListener.java
@@ -30,16 +30,21 @@ public class OreBreakListener implements Listener {
             return;
         }
 
+        if (plugin.consumePlayerPlaced(block.getLocation())) {
+            return;
+        }
+
         if (plugin.isCustomOre(type)) {
             return; // handled by BlockBreakListener
         }
 
-        if (!plugin.getSphereManager().isInsideSphere(block.getLocation())) {
+        Player player = event.getPlayer();
+        boolean bypass = player.isOp() || player.hasPermission("minesystem.admin");
+        if (!bypass && !plugin.getSphereManager().isInsideSphere(block.getLocation())) {
             event.setCancelled(true);
             return;
         }
 
-        Player player = event.getPlayer();
         ItemStack tool = player.getInventory().getItemInMainHand();
 
         Collection<ItemStack> drops = block.getDrops(tool);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,7 @@ mobs:
       amount: 3
 
 sell-prices:
-  world: # nazwa �wiata
+  world: # nazwa świata
     Hematite: 1000000
     BlackSpinel: 1750000
     BlackDiamond: 3000000

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,3 +32,7 @@ commands:
     description: Check your stamina
     usage: /stamin
     permission: minesystemplugin.mine
+permissions:
+  minesystem.admin:
+    description: Bypass mining restrictions
+    default: op


### PR DESCRIPTION
## Summary
- Drop bonus ore items every 20 custom-ore hits instead of waiting for complete breaks
- Allow ops or players with `minesystem.admin` to ignore sphere mining restrictions
- Let ores placed outside spheres be mined normally by tracking and skipping custom logic
- Declare `minesystem.admin` permission in plugin.yml
- Ignore special-block logic outside spheres so crystals, moss blocks, and bone blocks break normally
- Allow precise special loot chance editing with 10% clicks and 1% shift-clicks
- Serialize and restore full ItemStack data so loot retains names, lore, attributes, and other metadata

## Testing
- `mvn -q test` *(fails: PluginResolutionException – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b181d6090832a95882f1fb81f48d6