### PR TITLE
Enable mining in spheres for Adventure players

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
+++ b/src/main/java/org/maks/mineSystemPlugin/MineSystemPlugin.java
@@ -31,6 +31,7 @@ import org.maks.mineSystemPlugin.listener.BlockBreakListener;
 import org.maks.mineSystemPlugin.listener.BlockPlaceListener;
 import org.maks.mineSystemPlugin.listener.OreBreakListener;
 import org.maks.mineSystemPlugin.tool.ToolListener;
+import org.maks.mineSystemPlugin.listener.MinerElixirListener;
 import org.maks.mineSystemPlugin.SpecialBlockListener;
 import org.maks.mineSystemPlugin.CrystalEnchantCommand;
 import org.maks.mineSystemPlugin.RepairCommand;
@@ -158,6 +159,7 @@ public final class MineSystemPlugin extends JavaPlugin {
         registerListener(new BlockPlaceListener(this));
         registerListener(new OreBreakListener(this));
         registerListener(new ToolListener(this));
+        registerListener(new MinerElixirListener(staminaManager));
     }
 
     /**

--- a/src/main/java/org/maks/mineSystemPlugin/item/CustomItems.java
+++ b/src/main/java/org/maks/mineSystemPlugin/item/CustomItems.java
@@ -24,79 +24,79 @@ public final class CustomItems {
         // Black Ore (Coal-based)
         register("Hematite", Material.COAL_ORE, "&8Hematite",
                 List.of("&7A common black ore with metallic luster and reddish streaks.",
-                        "&eCoal-based mineral"), false, false);
+                        "&eCoal-based mineral"), true, true);
         register("BlackSpinel", Material.COAL_ORE, "&8Black Spinel",
                 List.of("&7An uncommon black crystal with exceptional hardness and luster.",
-                        "&eCoal-based gemstone"), false, false);
+                        "&eCoal-based gemstone"), true, true);
         register("BlackDiamond", Material.COAL_ORE, "&8&lBlack Diamond",
                 List.of("&7A rare and precious black diamond formed under extreme pressure.",
-                        "&eHighest quality coal gem"), false, false);
+                        "&eHighest quality coal gem"), true, true);
 
         // Metallic Ore (Iron-based)
         register("Magnetite", Material.IRON_ORE, "&7Magnetite",
                 List.of("&7A common metallic ore with magnetic properties.",
-                        "&eIron-based mineral"), false, false);
+                        "&eIron-based mineral"), true, true);
         register("Silver", Material.IRON_ORE, "&f&lSilver",
                 List.of("&7An uncommon precious metal with lustrous white appearance.",
-                        "&eIron-based metal"), false, false);
+                        "&eIron-based metal"), true, true);
         register("Osmium", Material.IRON_ORE, "&7&lOsmium",
                 List.of("&7A rare and dense bluish-white metal, one of the heaviest natural elements.",
-                        "&ePremium iron metal"), false, false);
+                        "&ePremium iron metal"), true, true);
 
         // Azure Ore (Lapis-based)
         register("Azurite", Material.LAPIS_ORE, "&9Azurite",
                 List.of("&7A common deep blue mineral with intense azure color.",
-                        "&eLapis-based mineral"), false, false);
+                        "&eLapis-based mineral"), true, true);
         register("Tanzanite", Material.LAPIS_ORE, "&9&lTanzanite",
                 List.of("&7An uncommon blue-purple gemstone known for its trichroic properties.",
-                        "&eLapis-based gem"), false, false);
+                        "&eLapis-based gem"), true, true);
         register("BlueSapphire", Material.LAPIS_ORE, "&1&lBlue Sapphire",
                 List.of("&7A rare and precious blue gemstone, second only to diamond in hardness.",
-                        "&ePremium lapis gem"), false, false);
+                        "&ePremium lapis gem"), true, true);
 
         // Crimson Ore (Redstone-based)
         register("Carnelian", Material.REDSTONE_ORE, "&cCarnelian",
                 List.of("&7A common reddish-orange mineral with translucent properties.",
-                        "&eRedstone-based mineral"), false, false);
+                        "&eRedstone-based mineral"), true, true);
         register("RedSpinel", Material.REDSTONE_ORE, "&c&lRed Spinel",
                 List.of("&7An uncommon vibrant red gemstone often mistaken for ruby.",
-                        "&eRedstone-based gem"), false, false);
+                        "&eRedstone-based gem"), true, true);
         register("PigeonBloodRuby", Material.REDSTONE_ORE, "&4&lPigeon Blood Ruby",
                 List.of("&7A rare and precious deep red gemstone with the coveted \"pigeon blood\" color.",
-                        "&ePremium redstone gem"), false, false);
+                        "&ePremium redstone gem"), true, true);
 
         // Golden Ore (Gold-based)
         register("Pyrite", Material.GOLD_ORE, "&ePyrite",
                 List.of("&7A common brassy-yellow mineral often called \"Fool`s Gold\".",
-                        "&eGold-based mineral"), false, false);
+                        "&eGold-based mineral"), true, true);
         register("YellowTopaz", Material.GOLD_ORE, "&e&lYellow Topaz",
                 List.of("&7An uncommon golden-yellow gemstone with excellent clarity.",
-                        "&eGold-based gem"), false, false);
+                        "&eGold-based gem"), true, true);
         register("YellowSapphire", Material.GOLD_ORE, "&6&lYellow Sapphire",
                 List.of("&7A rare and precious golden gemstone, prized for its brilliance and hardness.",
-                        "&ePremium gold gem"), false, false);
+                        "&ePremium gold gem"), true, true);
 
         // Verdant Ore (Emerald-based)
         register("Malachite", Material.EMERALD_ORE, "&aMalachite",
                 List.of("&7A common green mineral with distinctive banded patterns.",
-                        "&eEmerald-based mineral"), false, false);
+                        "&eEmerald-based mineral"), true, true);
         register("Peridot", Material.EMERALD_ORE, "&a&lPeridot",
                 List.of("&7An uncommon olive-green gemstone formed in volcanic environments.",
-                        "&eEmerald-based gem"), false, false);
+                        "&eEmerald-based gem"), true, true);
         register("TropicheEmerald", Material.EMERALD_ORE, "&2&lTropiche Emerald",
                 List.of("&7A rare and precious deep green gemstone with exceptional clarity and color.",
-                        "&ePremium emerald"), false, false);
+                        "&ePremium emerald"), true, true);
 
         // Prismatic Ore (Diamond-based)
         register("Danburite", Material.DIAMOND_ORE, "&fDanburite",
                 List.of("&7A common colorless crystal with diamond-like brilliance.",
-                        "&eDiamond-based mineral"), false, false);
+                        "&eDiamond-based mineral"), true, true);
         register("Goshenite", Material.DIAMOND_ORE, "&f&lGoshenite",
                 List.of("&7An uncommon colorless beryl with exceptional clarity.",
-                        "&eDiamond-based gemstone"), false, false);
+                        "&eDiamond-based gemstone"), true, true);
         register("Cerussite", Material.DIAMOND_ORE, "&f&l&nCerussite",
                 List.of("&7A rare and precious crystal with the highest refractive index.",
-                        "&eSupreme diamond gemstone"), false, false);
+                        "&eSupreme diamond gemstone"), true, true);
 
         // Bonus ore items
         register("ore_I", Material.COBBLESTONE, "&9[ I ] Ore",
@@ -125,6 +125,10 @@ public final class CustomItems {
         // Currency
         register("Crystal", Material.BRICK, "&d&lCrystal",
                 List.of("§o&7Mine currency"), true, true);
+
+        // Consumables
+        register("miner_elixir", Material.BEEF, "&5Miner Elixir",
+                List.of("&7Refresh Mining Stamin"), true, true);
     }
 
     private static void register(String id, Material material, String name,
@@ -139,11 +143,14 @@ public final class CustomItems {
                     .map(line -> ChatColor.translateAlternateColorCodes('&', line))
                     .toList());
         }
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES,
+                ItemFlag.HIDE_DESTROYS,
+                ItemFlag.HIDE_POTION_EFFECTS,
+                ItemFlag.HIDE_PLACED_ON);
         if (unbreakable) {
             meta.setUnbreakable(true);
             meta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE);
         }
-        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
         if (enchant) {
             meta.addEnchant(Enchantment.DURABILITY, 10, true);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);

--- a/src/main/java/org/maks/mineSystemPlugin/listener/MinerElixirListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/listener/MinerElixirListener.java
@@ -1,0 +1,67 @@
+package org.maks.mineSystemPlugin.listener;
+
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.block.Action;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.mineSystemPlugin.stamina.StaminaManager;
+
+/**
+ * Consumes a Miner Elixir on right click to fully restore the player's stamina.
+ */
+public class MinerElixirListener implements Listener {
+
+    private final StaminaManager stamina;
+
+    public MinerElixirListener(StaminaManager stamina) {
+        this.stamina = stamina;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onInteract(PlayerInteractEvent event) {
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        // Only process main-hand interactions to avoid double firing
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        if (item == null) {
+            // When clicking in the air, getItem may be null even if the player is holding the elixir
+            item = event.getPlayer().getInventory().getItem(event.getHand());
+            if (item == null) {
+                return;
+            }
+        }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !meta.hasDisplayName()) {
+            return;
+        }
+        String name = ChatColor.stripColor(meta.getDisplayName());
+        if (!"Miner Elixir".equalsIgnoreCase(name)) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        int max = stamina.getMaxStamina(player.getUniqueId());
+        if (stamina.getStamina(player.getUniqueId()) >= max) {
+            player.sendMessage("Your stamina is already full.");
+            return;
+        }
+
+        stamina.refillStamina(player.getUniqueId());
+        item.setAmount(item.getAmount() - 1);
+        player.sendMessage("Your stamina has been refreshed.");
+        event.setCancelled(true);
+    }
+}

--- a/src/main/java/org/maks/mineSystemPlugin/menu/LootEditMenu.java
+++ b/src/main/java/org/maks/mineSystemPlugin/menu/LootEditMenu.java
@@ -41,6 +41,7 @@ public class LootEditMenu implements InventoryHolder, Listener {
     private final Inventory inventory;
     private final NamespacedKey chanceKey;
     private boolean cancelClicked = false;
+    private boolean saveClicked = false;
 
     public LootEditMenu(JavaPlugin plugin, LootRepository storage, LootManager lootManager) {
         this.plugin = plugin;
@@ -139,6 +140,7 @@ public class LootEditMenu implements InventoryHolder, Listener {
             event.setCancelled(true);
 
             if (slot == SAVE_SLOT) {
+                saveClicked = true;
                 saveChanges();
                 event.getWhoClicked().closeInventory();
                 return;
@@ -226,7 +228,7 @@ public class LootEditMenu implements InventoryHolder, Listener {
             return;
         }
         HandlerList.unregisterAll(this);
-        if (!cancelClicked) {
+        if (!cancelClicked && !saveClicked) {
             saveChanges();
         }
     }

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereListener.java
@@ -3,7 +3,9 @@ package org.maks.mineSystemPlugin.sphere;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 
 /**
  * Listens for player events relevant to spheres.
@@ -24,5 +26,20 @@ public class SphereListener implements Listener {
     @EventHandler
     public void onDeath(PlayerDeathEvent event) {
         manager.removeSphereOnDeath(event.getEntity());
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (event.getFrom().getBlockX() == event.getTo().getBlockX()
+                && event.getFrom().getBlockY() == event.getTo().getBlockY()
+                && event.getFrom().getBlockZ() == event.getTo().getBlockZ()) {
+            return;
+        }
+        manager.handleMove(event.getPlayer(), event.getTo());
+    }
+
+    @EventHandler
+    public void onTeleport(PlayerTeleportEvent event) {
+        manager.handleMove(event.getPlayer(), event.getTo());
     }
 }

--- a/src/main/java/org/maks/mineSystemPlugin/stamina/StaminaManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/stamina/StaminaManager.java
@@ -122,6 +122,16 @@ public class StaminaManager {
         playerRepository.save(new PlayerData(uuid, ps.getStamina(), reset));
     }
 
+    /**
+     * Restores a player's stamina to its maximum and clears any active reset timer.
+     */
+    public void refillStamina(UUID uuid) {
+        PlayerStamina ps = getData(uuid);
+        ps.setStamina(ps.getMaxStamina());
+        ps.setFirstUsage(null);
+        playerRepository.save(new PlayerData(uuid, ps.getStamina(), 0L));
+    }
+
     public void saveAll() {
         staminaMap.forEach((uuid, ps) -> {
             long reset = ps.getFirstUsage() == null ? 0L : ps.getFirstUsage().toEpochMilli();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,3 +27,6 @@ sell-prices:
     Danburite: 2500000
     Goshenite: 4375000
     Cerussite: 7500000
+
+debug:
+  toolListener: false


### PR DESCRIPTION
## Summary
- Switch players to SURVIVAL when they enter a sphere and restore their previous mode on exit or sphere removal
- Log game mode transitions when `debug.toolListener` is enabled
- Handle player movement and teleport events to keep game modes in sync with sphere boundaries

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b45f9e4c8832a81c8d1b8ce87ee37