### PR TITLE
Restrict block breaking to plugin tools

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
@@ -58,6 +58,8 @@ public final class CustomTool {
         NamespacedKey curKey = new NamespacedKey(plugin, "durability");
         pdc.set(maxKey, PersistentDataType.INTEGER, material.getMaxDurability());
         pdc.set(curKey, PersistentDataType.INTEGER, material.getMaxDurability());
+        NamespacedKey markerKey = new NamespacedKey(plugin, "custom_tool");
+        pdc.set(markerKey, PersistentDataType.BYTE, (byte) 1);
 
         // allowed blocks restriction
         if (canDestroy != null && !canDestroy.isEmpty()) {

--- a/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
@@ -3,6 +3,7 @@ package org.maks.mineSystemPlugin.tool;
 import java.util.Collection;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -11,6 +12,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 import org.maks.mineSystemPlugin.MineSystemPlugin;
 
 /**
@@ -20,10 +22,12 @@ public class ToolListener implements Listener {
 
     private final MineSystemPlugin plugin;
     private final boolean debug;
+    private final NamespacedKey toolKey;
 
     public ToolListener(MineSystemPlugin plugin) {
         this.plugin = plugin;
         this.debug = plugin.getConfig().getBoolean("debug.toolListener", false);
+        this.toolKey = new NamespacedKey(plugin, "custom_tool");
     }
 
     /**
@@ -95,10 +99,20 @@ public class ToolListener implements Listener {
     }
 
     private boolean canDestroy(ItemStack tool, Block block) {
-        if (!tool.hasItemMeta()) return true;
-        var meta = tool.getItemMeta();
+        if (!tool.hasItemMeta()) {
+            return false;
+        }
+        ItemMeta meta = tool.getItemMeta();
+
+        // Only allow tools created by this plugin
+        if (!meta.getPersistentDataContainer().has(toolKey, PersistentDataType.BYTE)) {
+            return false;
+        }
+
         var canDestroy = meta.getCanDestroy();
-        if (canDestroy == null || canDestroy.isEmpty()) return true;
+        if (canDestroy == null || canDestroy.isEmpty()) {
+            return false;
+        }
         return canDestroy.contains(block.getType());
     }
 


### PR DESCRIPTION
## Summary
- deny sphere block breaking unless tool has `custom_tool` marker and valid CanDestroy list
- tag newly created tools with a persistent `custom_tool` key

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b604b1334832a95ea4c6f2a4a0da7