### PR TITLE
Streamline special loot and add preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,84 @@
 # MineSystemPlugin
 
-This plugin adds custom mining mechanics such as timed spheres and special ores.
+MineSystemPlugin adds an instanced mining experience to Paper/Spigot servers.
+Players enter temporary spheres built from schematics and gather custom ores,
+fight mobs or bosses, and earn configurable loot and currency.
+
+## Features
+- Weighted random sphere generation using WorldEdit schematics
+- Custom ores with durability and random variants
+- Timed spheres that clear themselves and remove spawned mobs
+- Loot editor GUI and per-schematic special loot with Save/Cancel controls
+- Optional Citizens NPCs for special1.schem and special2.schem
+- Mob spawning that requires a solid ceiling to keep entities inside
+- Stamina system with quest-based max stamina bonuses
+- Pickaxe repair/enchant commands using Crystal currency
+- Database-backed persistence for players, pickaxes, loot and schematics
+
+## Requirements
+- Java 17+
+- Paper/Spigot 1.20.1 server
+- [Vault](https://www.spigotmc.org/resources/vault.34315/) for economy support
+- [FastAsyncWorldEdit](https://www.spigotmc.org/resources/fast-async-worldedit-fawe.13932/) or WorldEdit for schematics
+- [MythicMobs](https://www.mythicmobs.net/) for custom mob spawns
+- [Citizens](https://www.spigotmc.org/resources/citizens.13811/) if using special sphere NPCs
+- MySQL database (via HikariCP)
+
+## Building
+1. Clone the repository
+2. Run `mvn package`
+3. Copy `target/minesystemplugin-1.0-SNAPSHOT.jar` to your server's `plugins` folder
+
+## Configuration
+Configuration is stored in `plugins/MineSystemPlugin/config.yml`.
+
+### Database
+Provide MySQL connection details under the `database` section:
+
+```yaml
+database:
+  host: localhost
+  port: 3306
+  name: minesystem
+  user: root
+  password: secret
+```
+
+### Mob spawns
+Define custom mobs tied to schematics:
+
+```yaml
+mobs:
+  example.schem:
+    - name: ExampleMob
+      mythic_id: example_id
+      amount: 3
+```
+
+Each entry is spawned when the schematic is pasted.
+
+### Sell prices
+`config.yml` maps custom ore IDs to sell prices per world:
+
+```yaml
+sell-prices:
+  world:
+    Hematite: 1000000
+    BlackSpinel: 1750000
+    ...
+```
+
+### Debug flags
+Toggle various debug logs:
+
+```yaml
+debug:
+  toolListener: false
+```
 
 ## Sphere schematics
-
-Schematics are loaded from `plugins/MineSystemPlugin/schematics/<Type>` where
-`<Type>` is one of:
+Schematics live under `plugins/MineSystemPlugin/schematics/<Type>` where `<Type>`
+is one of:
 
 - `Ore`
 - `Treasure`
@@ -13,17 +86,69 @@ Schematics are loaded from `plugins/MineSystemPlugin/schematics/<Type>` where
 - `Mob`
 - `Boss`
 - `SpecialEvent`
-- `Puzzle`
 - `CrystalDust`
 
-Files can have any name as long as they end with the `.schem` extension. The
-plugin randomly selects the sphere type based on configured weights and then
-chooses a random schematic from the corresponding folder.
+Files must use the `.schem` extension. The plugin chooses a sphere type based on
+built‑in weights and then selects a random schematic from that folder. If a type
+has no schematics, it is removed from the pool and remaining weights are
+renormalized so the total chance stays 100 %.
 
-## Registering Event Listeners
+## Special spheres
+When `special1.schem` or `special2.schem` is pasted, the plugin clones a
+Citizens NPC onto the diamond block at the sphere's center:
 
-Event listeners are registered through the Bukkit `PluginManager`. The main plugin
-class exposes a helper method for convenience:
+| Schematic       | Template NPC ID |
+| --------------- | --------------- |
+| `special1.schem`| 61              |
+| `special2.schem`| 62              |
+
+The copied NPC is removed again when the sphere expires.
+
+## Loot editing
+Use `/loot` to edit global sphere loot and `/specialloot <schematic>` for
+schematic‑specific rewards. The schematic name may be given with or without
+the `.schem` extension. `/specialloot test <schematic>` previews the random
+loot for a schematic. Both edit commands open a 54‑slot inventory:
+
+- Items dragged from the player's inventory into the GUI are added with a
+  default 50 % chance.
+- Change a chance by clicking an item.
+- Use the green **Save** wool to persist changes to the database or red **Cancel**
+  to discard.
+- Special loot menus also save automatically when closed.
+
+## Stamina system
+Players consume stamina when entering spheres. Stamina regenerates after a delay
+and can be increased through quests. `/stamin` shows the current amount and time
+until reset.
+
+## Pickaxes and crystals
+Mining uses custom pickaxes tracked in the database. `/mine_repair` restores
+durability using crystals and `/mine_enchant` applies crystal‑based enchants.
+Random bonus items may drop when a sphere is completed.
+
+## Commands
+
+| Command | Description | Permission |
+|---------|-------------|------------|
+| `/loot` | Manage loot configuration | `minesystemplugin.loot` |
+| `/mine` | Open the mine selection menu | `minesystemplugin.mine` |
+| `/mine_repair` | Repair the item in hand using crystals | `minesystemplugin.mine` |
+| `/mine_enchant` | Enchant a pickaxe using crystals | `minesystemplugin.mine` |
+| `/spawnsphere` | Spawn a sphere for testing | `minesystemplugin.mine` |
+| `/specialloot <schematic>` | Edit loot for a specific schematic (extension optional) | `minesystemplugin.mine` |
+| `/specialloot test <schematic>` | Preview generated special loot (extension optional) | `minesystemplugin.mine` |
+| `/stamin` | Check your stamina | `minesystemplugin.mine` |
+
+The `minesystem.admin` permission bypasses mining restrictions.
+
+## API events
+Other plugins can listen for:
+
+- `OreMinedEvent` – fired when a custom ore is broken
+- `SphereCompleteEvent` – fired when a sphere finishes
+
+Register listeners through Bukkit's `PluginManager`:
 
 ```java
 private void registerListener(Listener listener) {
@@ -31,14 +156,8 @@ private void registerListener(Listener listener) {
 }
 ```
 
-Call this method from `onEnable` to hook your listener:
+Call this method from `onEnable` to hook your listener.
 
-```java
-@Override
-public void onEnable() {
-    registerListener(new MyCustomListener());
-}
-```
+## License
+*(Add license information here if applicable.)*
 
-Your listener can then react to custom events like `OreMinedEvent` and
-`SphereCompleteEvent`.

--- a/src/main/java/org/maks/mineSystemPlugin/command/SpecialLootCommand.java
+++ b/src/main/java/org/maks/mineSystemPlugin/command/SpecialLootCommand.java
@@ -1,9 +1,11 @@
 package org.maks.mineSystemPlugin.command;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.maks.mineSystemPlugin.SpecialLootManager;
 import org.maks.mineSystemPlugin.menu.SpecialLootMenu;
@@ -25,15 +27,38 @@ public class SpecialLootCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (args.length < 1) {
-            sender.sendMessage("Usage: /specialloot <schematic>");
+        if (args.length == 0) {
+            sender.sendMessage("Usage: /specialloot <schematic> | /specialloot test <schematic>");
             return true;
         }
+
+        if (args[0].equalsIgnoreCase("test")) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage("Only players can use this command.");
+                return true;
+            }
+            if (args.length < 2) {
+                sender.sendMessage("Usage: /specialloot test <schematic>");
+                return true;
+            }
+            String schem = args[1];
+            if (!schem.endsWith(".schem")) {
+                schem += ".schem";
+            }
+            Inventory inv = Bukkit.createInventory(null, 27, "Special Loot Test");
+            manager.fillInventory(schem, inv);
+            player.openInventory(inv);
+            return true;
+        }
+
         if (!(sender instanceof Player player)) {
             sender.sendMessage("Only players can use this command.");
             return true;
         }
         String schem = args[0];
+        if (!schem.endsWith(".schem")) {
+            schem += ".schem";
+        }
         SpecialLootMenu menu = new SpecialLootMenu(plugin, schem, storage, manager);
         player.openInventory(menu.getInventory());
         return true;

--- a/src/main/java/org/maks/mineSystemPlugin/repository/SpecialLootRepository.java
+++ b/src/main/java/org/maks/mineSystemPlugin/repository/SpecialLootRepository.java
@@ -55,8 +55,9 @@ public class SpecialLootRepository {
                     del.setString(1, schematic);
                     del.executeUpdate();
                 }
+
                 try (PreparedStatement ps = con.prepareStatement(
-                        "INSERT INTO special_loot(schematic, item, chance) VALUES(?, ?, ?)");) {
+                        "INSERT INTO special_loot(schematic, item, chance) VALUES(?, ?, ?)")) {
                     for (SpecialLootEntry entry : items) {
                         ps.setString(1, schematic);
                         ps.setString(2, ItemSerializer.serialize(entry.item()));

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/Sphere.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/Sphere.java
@@ -28,9 +28,10 @@ public class Sphere {
     private final Location origin;
     private final List<ArmorStand> holograms;
     private final List<BukkitTask> warningTasks;
+    private final String schematicName;
 
     public Sphere(SphereType type, Region region, BukkitTask expiryTask, World world, Location origin,
-                  List<ArmorStand> holograms, List<BukkitTask> warningTasks) {
+                  List<ArmorStand> holograms, List<BukkitTask> warningTasks, String schematicName) {
         this.type = type;
         this.region = region;
         this.expiryTask = expiryTask;
@@ -38,6 +39,7 @@ public class Sphere {
         this.origin = origin;
         this.holograms = holograms;
         this.warningTasks = warningTasks;
+        this.schematicName = schematicName;
     }
 
     public SphereType getType() {
@@ -50,6 +52,10 @@ public class Sphere {
 
     public World getWorld() {
         return world;
+    }
+
+    public String getSchematicName() {
+        return schematicName;
     }
 
     /**

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -49,6 +49,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * Manages active mining spheres.
@@ -171,12 +173,19 @@ public class SphereManager {
         }
         stamina.deductStamina(player.getUniqueId(), 10);
 
-        SphereType type = SphereType.random();
-        File folder = new File(plugin.getDataFolder(), "schematics/" + type.getFolderName());
-        if (!folder.exists()) {
-            player.sendMessage("No schematics for type " + type.name());
+        List<SphereType> options = Arrays.stream(SphereType.values())
+                .filter(t -> {
+                    File f = new File(plugin.getDataFolder(), "schematics/" + t.getFolderName());
+                    File[] s = f.listFiles((dir, name) -> name.endsWith(".schem"));
+                    return s != null && s.length > 0;
+                })
+                .collect(Collectors.toList());
+        if (options.isEmpty()) {
+            player.sendMessage("No schematics found");
             return false;
         }
+        SphereType type = SphereType.random(options);
+        File folder = new File(plugin.getDataFolder(), "schematics/" + type.getFolderName());
         File[] schems = folder.listFiles((dir, name) -> name.endsWith(".schem"));
         if (schems == null || schems.length == 0) {
             player.sendMessage("No schematics found");
@@ -195,6 +204,7 @@ public class SphereManager {
             Clipboard clipboard = reader.read();
             Map<BlockVector3, OreVariant> variants = replacePlaceholders(clipboard, premium);
             BlockVector3 goldVec = findGoldBlock(clipboard);
+            BlockVector3 diamondVec = findDiamondBlock(clipboard);
 
             Region clipRegion = clipboard.getRegion();
             BlockVector3 pastePos = BlockVector3.at(origin.getBlockX(), origin.getBlockY(), origin.getBlockZ());
@@ -244,7 +254,7 @@ public class SphereManager {
                 }
             }.runTaskTimer(plugin, LIFE_TIME_TICKS - 200L, 20L));
 
-            Sphere sphere = new Sphere(type, region, task, origin.getWorld(), origin, holograms, warnings);
+            Sphere sphere = new Sphere(type, region, task, origin.getWorld(), origin, holograms, warnings, schematic.getName());
             active.put(player.getUniqueId(), sphere);
             sphereRepository.save(new SphereData(player.getUniqueId(), type.name(), System.currentTimeMillis()));
             Location teleport;
@@ -257,13 +267,27 @@ public class SphereManager {
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
                 player.teleport(teleport);
                 handleMove(player, teleport);
-                String coords = String.format("%d %d %d", teleport.getBlockX(), teleport.getBlockY() - 1, teleport.getBlockZ());
-                player.sendMessage(ChatColor.YELLOW + "Teleported to sphere at " + coords);
-
             }, 40L);
             int baseY = teleport.getBlockY();
             Bukkit.getScheduler().runTaskLater(plugin,
                     () -> spawnConfiguredMobs(schematic.getName(), region, origin.getWorld(), baseY), 20L);
+
+            if (schematic.getName().equals("special1.schem") || schematic.getName().equals("special2.schem")) {
+                int selectId = schematic.getName().equals("special1.schem") ? 61 : 62;
+                if (diamondVec != null) {
+                    BlockVector3 d = diamondVec.add(shift);
+                    Location npcLoc = new Location(origin.getWorld(), d.getX() + 0.5, d.getY() + 1, d.getZ() + 0.5);
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        String worldName = origin.getWorld().getName();
+                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "npc select " + selectId);
+                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "npc copy");
+                        String cmd = String.format(
+                                "npc moveto --world %s --x %.1f --y %.1f --z %.1f",
+                                worldName, npcLoc.getX(), npcLoc.getY(), npcLoc.getZ());
+                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
+                    }, 60L);
+                }
+            }
             return true;
         } catch (IOException | WorldEditException e) {
             player.sendMessage("Failed to create sphere");
@@ -320,6 +344,17 @@ public class SphereManager {
         return null;
     }
 
+    private BlockVector3 findDiamondBlock(Clipboard clipboard) {
+        Region region = clipboard.getRegion();
+        for (BlockVector3 vec : region) {
+            BlockState state = clipboard.getBlock(vec);
+            if (state.getBlockType().getId().equals("minecraft:diamond_block")) {
+                return vec;
+            }
+        }
+        return null;
+    }
+
     private List<ArmorStand> spawnHolograms(World world, Map<BlockVector3, OreVariant> variants, BlockVector3 shift) {
         List<ArmorStand> list = new ArrayList<>();
         MineSystemPlugin pluginImpl = (MineSystemPlugin) plugin;
@@ -349,13 +384,14 @@ public class SphereManager {
     private void populateChests(World world, Region region, SphereType type, String schematicName) {
         MineSystemPlugin pluginImpl = (MineSystemPlugin) plugin;
         SpecialLootManager special = pluginImpl.getSpecialLootManager();
-        Map<Material, SpecialLootEntry> specialLoot = (Map<Material, SpecialLootEntry>) special.getLoot(schematicName);
+        List<SpecialLootEntry> specialLoot = special.getLoot(schematicName);
         LootManager loot = pluginImpl.getLootManager();
-        boolean treasure = type == SphereType.TREASURE && (specialLoot == null || specialLoot.isEmpty());
+        boolean hasSpecial = specialLoot != null && !specialLoot.isEmpty();
+        boolean treasure = type == SphereType.TREASURE && !hasSpecial;
         for (BlockVector3 vec : region) {
             Block block = world.getBlockAt(vec.getX(), vec.getY(), vec.getZ());
             if (block.getState() instanceof Chest chest) {
-                if (specialLoot != null && !specialLoot.isEmpty()) {
+                if (hasSpecial) {
                     special.fillInventory(schematicName, chest.getBlockInventory());
                 } else if (treasure) {
                     loot.fillInventory(chest.getBlockInventory());
@@ -449,7 +485,9 @@ public class SphereManager {
             Block block = world.getBlockAt(x, y, z);
             Block above = world.getBlockAt(x, y + 1, z);
             Block below = world.getBlockAt(x, y - 1, z);
-            if (block.getType() == Material.AIR && above.getType() == Material.AIR && below.getType().isSolid()) {
+            Block twoAbove = world.getBlockAt(x, y + 2, z);
+            if (block.getType() == Material.AIR && above.getType() == Material.AIR && below.getType().isSolid()
+                    && twoAbove.getType().isSolid()) {
                 return new Location(world, x + 0.5, y, z + 0.5);
             }
         }
@@ -540,6 +578,9 @@ public class SphereManager {
                 );
             }
             sphere.remove();
+            if ("special1.schem".equals(sphere.getSchematicName()) || "special2.schem".equals(sphere.getSchematicName())) {
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "npc rem");
+            }
             clearHolograms(sphere);
             sphereRepository.save(new SphereData(uuid, sphere.getType().name(), 0L));
         }

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereType.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereType.java
@@ -14,7 +14,6 @@ public enum SphereType {
     MOB("Mob", 15),
     BOSS("Boss", 3),
     SPECIAL_EVENT("SpecialEvent", 5),
-    PUZZLE("Puzzle", 7),
     CRYSTAL_DUST("CrystalDust", 5);
 
     private static final Random RANDOM = new Random();
@@ -39,7 +38,14 @@ public enum SphereType {
      * Chooses a random sphere type using the configured weights.
      */
     public static SphereType random() {
-        List<SphereType> types = Arrays.asList(values());
+        return random(Arrays.asList(values()));
+    }
+
+    /**
+     * Chooses a random sphere type from the provided list, normalizing weights
+     * so that excluded types do not skew the distribution.
+     */
+    public static SphereType random(List<SphereType> types) {
         int total = types.stream().mapToInt(SphereType::getWeight).sum();
         int r = RANDOM.nextInt(total);
         int current = 0;
@@ -49,6 +55,6 @@ public enum SphereType {
                 return type;
             }
         }
-        return ORE; // Fallback
+        return types.get(0); // Fallback
     }
 }


### PR DESCRIPTION
## Summary
- fix chest population by using configured special loot lists
- add `/specialloot test <schematic>` to preview loot for a specific schematic
- document the new test command and optional `.schem` suffix

## Testing
- `mvn -q -e test` *(Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c7cea557c832a99cd903dbfcfcd90