### PR TITLE
Handle schematic keys containing dots when spawning mobs

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -30,6 +30,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.configuration.ConfigurationSection;
 import org.maks.mineSystemPlugin.events.SphereCompleteEvent;
 import org.maks.mineSystemPlugin.LootManager;
 import org.maks.mineSystemPlugin.MineSystemPlugin;
@@ -510,6 +511,22 @@ public class SphereManager {
     private void spawnConfiguredMobs(String schematic, Region region, World world,
                                      Player player, Location bossLoc) {
         List<Map<?, ?>> entries = ((JavaPlugin) plugin).getConfig().getMapList("mobs." + schematic);
+        if (entries.isEmpty()) {
+            ConfigurationSection mobs = ((JavaPlugin) plugin).getConfig().getConfigurationSection("mobs");
+            if (mobs != null) {
+                Object raw = mobs.getValues(false).get(schematic);
+                if (raw instanceof List<?>) {
+                    entries = new ArrayList<>();
+                    for (Object o : (List<?>) raw) {
+                        if (o instanceof Map<?, ?> map) {
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object> casted = (Map<String, Object>) map;
+                            entries.add(casted);
+                        }
+                    }
+                }
+            }
+        }
         for (Map<?, ?> entry : entries) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) entry;


### PR DESCRIPTION
## Summary
- Correct mob spawn lookup so bosses defined under schematic names with dots spawn on the diamond block
- Import ConfigurationSection for new configuration handling
- Fallback to traditional map list lookup to keep existing mob spawns working

## Testing
- ⚠️ `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to sonatype-oss (https://s01.oss.sonatype.org/content/groups/public/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cbeb77ad4832ab3bb8d5dff194eb1