### PR TITLE
Handle schematic keys containing dots when spawning mobs

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -509,7 +509,8 @@ public class SphereManager {
 
     private void spawnConfiguredMobs(String schematic, Region region, World world,
                                      Player player, Location bossLoc) {
-        List<Map<?, ?>> entries = ((JavaPlugin) plugin).getConfig().getMapList("mobs." + schematic);
+        String key = "mobs." + schematic.replace(".", "\\.");
+        List<Map<?, ?>> entries = ((JavaPlugin) plugin).getConfig().getMapList(key);
         for (Map<?, ?> entry : entries) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) entry;


### PR DESCRIPTION
## Summary
- Escape dots in schematic names before mob lookup so spawn commands run

## Testing
- ⚠️ `mvn -q -e -DskipTests package` *(Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to sonatype-oss (https://s01.oss.sonatype.org/content/groups/public/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cbeb77ad4832ab3bb8d5dff194eb1