### PR TITLE
Handle schematic dots and validate mob spawn positions

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -25,9 +25,11 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
+import org.bukkit.FluidCollisionMode;
 import org.bukkit.util.Vector;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.maks.mineSystemPlugin.events.SphereCompleteEvent;
@@ -252,6 +254,9 @@ public class SphereManager {
             Map<BlockVector3, OreVariant> variants = replacePlaceholders(clipboard, premium);
             BlockVector3 goldVec = findGoldBlock(clipboard);
             BlockVector3 diamondVec = findDiamondBlock(clipboard);
+            if (diamondVec == null) {
+                plugin.getLogger().warning("[SphereManager] Diamond block not found in schematic; boss will not spawn");
+            }
 
 
             loadRegionChunks(origin.getWorld(), region);
@@ -305,10 +310,6 @@ public class SphereManager {
             } else {
                 teleport = origin.clone().add(0.5, 1, 0.5);
             }
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                player.teleport(teleport);
-                handleMove(player, teleport);
-            }, 40L);
             Location bossLoc = null;
             if (diamondVec != null) {
                 BlockVector3 d = diamondVec.add(shift);
@@ -317,9 +318,14 @@ public class SphereManager {
             Location finalBossLoc = bossLoc;
             Region finalRegion = region;
             Location finalOrigin = origin;
-            Bukkit.getScheduler().runTaskLater(plugin,
-                    () -> spawnConfiguredMobs(schematic.getName(), finalRegion, finalOrigin.getWorld(),
-                            player, finalBossLoc), 20L);
+            String schemName = schematic.getName();
+            plugin.getLogger().info("[SphereManager] Scheduling teleport and mob spawn for " + schemName);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                player.teleport(teleport);
+                handleMove(player, teleport);
+                plugin.getLogger().info("[SphereManager] Running mob spawn for " + schemName);
+                spawnConfiguredMobs(schemName, finalRegion, finalOrigin.getWorld(), player, finalBossLoc);
+            }, 40L);
 
             if (schematic.getName().equals("special1.schem") || schematic.getName().equals("special2.schem")) {
                 int selectId = schematic.getName().equals("special1.schem") ? 61 : 62;
@@ -509,47 +515,131 @@ public class SphereManager {
 
     private void spawnConfiguredMobs(String schematic, Region region, World world,
                                      Player player, Location bossLoc) {
-        List<Map<?, ?>> entries = ((JavaPlugin) plugin).getConfig().getMapList("mobs." + schematic);
+        String key = "mobs." + schematic.replace(".", "\\.");
+        plugin.getLogger().info("[SphereManager] Loading mob config at key: " + key);
+        List<Map<?, ?>> entries = ((JavaPlugin) plugin).getConfig().getMapList(key);
+        if (entries.isEmpty()) {
+            plugin.getLogger().warning("[SphereManager] No entries found via getMapList, attempting fallback");
+            ConfigurationSection section = ((JavaPlugin) plugin).getConfig().getConfigurationSection("mobs");
+            if (section != null) {
+                Object raw = section.get(schematic);
+                if (raw instanceof List<?>) {
+                    //noinspection unchecked
+                    entries = (List<Map<?, ?>>) raw;
+                }
+            }
+        }
+        plugin.getLogger().info("[SphereManager] Found " + entries.size() + " mob entries");
         for (Map<?, ?> entry : entries) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) entry;
             String mythic = (String) map.get("mythic_id");
             Number amtNum = (Number) map.getOrDefault("amount", 1);
             int amount = amtNum.intValue();
-            boolean boss = Boolean.TRUE.equals(map.get("boss"));
+            Object bossObj = map.get("boss");
+            boolean boss = bossObj != null && Boolean.parseBoolean(String.valueOf(bossObj));
+            plugin.getLogger().info("[SphereManager] Spawning " + amount + " of " + mythic + (boss ? " (boss)" : ""));
             for (int i = 0; i < amount; i++) {
-                Location loc = boss && bossLoc != null
-                        ? bossLoc
-                        : randomSpawnNearPlayer(region, world, player);
+                Location loc;
+                if (boss) {
+                    if (bossLoc == null) {
+                        plugin.getLogger().warning("[SphereManager] Boss location missing, skipping spawn of " + mythic);
+                        continue;
+                    }
+                    if (!isValidSpawnLocation(world, bossLoc.getBlockX(), bossLoc.getBlockY(), bossLoc.getBlockZ(), null)) {
+                        plugin.getLogger().warning("[SphereManager] Boss location blocked, skipping spawn of " + mythic);
+                        continue;
+                    }
+                    loc = bossLoc;
+                } else {
+                    loc = randomSpawnNearPlayer(region, world, player);
+                }
+
+                String locString = loc == null
+                        ? "null"
+                        : String.format("%s,%.1f,%.1f,%.1f", world.getName(),
+                                loc.getX(), loc.getY(), loc.getZ());
+                String cmd = String.format("mm m spawn %s 1 %s", mythic, locString);
                 if (loc != null && mythic != null) {
-                    String cmd = String.format("mm m spawn %s 1 %s,%.1f,%.1f,%.1f",
-                            mythic, world.getName(), loc.getX(), loc.getY(), loc.getZ());
+                    plugin.getLogger().info("[SphereManager] Dispatching command: " + cmd);
                     Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
+                } else {
+                    plugin.getLogger().warning("[SphereManager] Missing location or mythic id for spawn, skipping. Intended command: " + cmd);
                 }
             }
         }
     }
 
-    private Location randomSpawnNearPlayer(Region region, World world, Player player) {
-        Location base = player.getLocation();
-        Vector dir = base.getDirection().setY(0).normalize();
-        for (int i = 0; i < 40; i++) {
-            double dist = 2 + random.nextDouble() * 2; // 2-4 blocks ahead
-            double angle = (random.nextDouble() - 0.5) * Math.PI / 3; // +/-30 degrees
-            Vector offset = dir.clone().rotateAroundY(angle).multiply(dist);
-            int x = base.getBlockX() + (int) Math.round(offset.getX());
-            int z = base.getBlockZ() + (int) Math.round(offset.getZ());
-            int y = base.getBlockY();
+    private boolean isValidSpawnLocation(World world, int x, int y, int z, Player player) {
+        Block block = world.getBlockAt(x, y, z);
+        if (block.getType() != Material.AIR) {
+            return false;
+        }
+        Block below = world.getBlockAt(x, y - 1, z);
+        if (!below.getType().isSolid()) {
+            return false;
+        }
+        Block above = world.getBlockAt(x, y + 1, z);
+        if (above.getType() != Material.STONE_BRICKS) {
+            for (int i = 1; i <= 6; i++) {
+                if (world.getBlockAt(x, y + i, z).getType() != Material.AIR) {
+                    return false;
+                }
+            }
+            if (world.getBlockAt(x, y + 7, z).getType() == Material.AIR) {
+                return false;
+            }
+        }
+        if (player != null) {
+            Location eye = player.getEyeLocation();
+            Location target = new Location(world, x + 0.5, y, z + 0.5);
+            Vector dir = target.toVector().subtract(eye.toVector());
+            if (world.rayTraceBlocks(eye, dir.normalize(), dir.length(), FluidCollisionMode.NEVER, true) != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Location findSpawnInColumn(int x, int z, Region region, World world, Player player) {
+        int minY = region.getMinimumPoint().getBlockY();
+        int maxY = region.getMaximumPoint().getBlockY();
+        for (int y = maxY; y >= minY; y--) {
             if (!region.contains(BlockVector3.at(x, y, z))) {
                 continue;
             }
-            Block block = world.getBlockAt(x, y, z);
-            Block above = world.getBlockAt(x, y + 1, z);
-            Block below = world.getBlockAt(x, y - 1, z);
-            Block twoAbove = world.getBlockAt(x, y + 2, z);
-            if (block.getType() == Material.AIR && above.getType() == Material.AIR && below.getType().isSolid()
-                    && twoAbove.getType().isSolid()) {
+            if (isValidSpawnLocation(world, x, y, z, player)) {
                 return new Location(world, x + 0.5, y, z + 0.5);
+            }
+        }
+        return null;
+    }
+
+    private Location randomSpawnNearPlayer(Region region, World world, Player player) {
+        Location base = player.getLocation();
+        for (int i = 0; i < 40; i++) {
+            double dist = 5 + random.nextDouble() * 3; // 5-8 blocks around
+            double angle = random.nextDouble() * Math.PI * 2; // full circle
+            Vector offset = new Vector(Math.cos(angle), 0, Math.sin(angle)).multiply(dist);
+            int x = base.getBlockX() + (int) Math.round(offset.getX());
+            int z = base.getBlockZ() + (int) Math.round(offset.getZ());
+            Location loc = findSpawnInColumn(x, z, region, world, player);
+            if (loc != null) {
+                return loc;
+            }
+        }
+
+        int minX = region.getMinimumPoint().getBlockX();
+        int maxX = region.getMaximumPoint().getBlockX();
+        int minZ = region.getMinimumPoint().getBlockZ();
+        int maxZ = region.getMaximumPoint().getBlockZ();
+
+        for (int i = 0; i < 80; i++) {
+            int x = random.nextInt(maxX - minX + 1) + minX;
+            int z = random.nextInt(maxZ - minZ + 1) + minZ;
+            Location loc = findSpawnInColumn(x, z, region, world, player);
+            if (loc != null) {
+                return loc;
             }
         }
         return null;


### PR DESCRIPTION
## Summary
- Robustly parse `boss` flag and validate diamond-block spawn points so bosses appear on the correct block inside the sphere
- Search vertical columns for valid positions, keeping all mob spawns within the sphere even when terrain height varies
- Skip line-of-sight checks when none are needed and only dispatch spawn commands for fully defined locations

## Testing
- ❌ `mvn -q -e -DskipTests package` (Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_689cbeb77ad4832ab3bb8d5dff194eb1