### PR TITLE
Hide default pickaxe attributes and revamp sell menu layout

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/menu/MineMenu.java
+++ b/src/main/java/org/maks/mineSystemPlugin/menu/MineMenu.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.permissions.PermissionAttachment;
 import org.maks.mineSystemPlugin.sphere.SphereManager;
@@ -45,6 +46,7 @@ public class MineMenu implements InventoryHolder, Listener {
         ItemMeta normalMeta = normal.getItemMeta();
         if (normalMeta != null) {
             normalMeta.setDisplayName(ChatColor.GRAY + "Regular Mine");
+            normalMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
             normal.setItemMeta(normalMeta);
         }
         inventory.setItem(12, normal);
@@ -53,6 +55,7 @@ public class MineMenu implements InventoryHolder, Listener {
         ItemMeta premiumMeta = premium.getItemMeta();
         if (premiumMeta != null) {
             premiumMeta.setDisplayName(ChatColor.AQUA + "Premium Mine");
+            premiumMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
             premium.setItemMeta(premiumMeta);
         }
         inventory.setItem(14, premium);

--- a/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
@@ -45,6 +45,7 @@ public final class CustomTool {
         }
 
         meta.displayName(Component.text(name));
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
 
         // base lore with durability line
         List<String> lore = new ArrayList<>();
@@ -79,17 +80,23 @@ public final class CustomTool {
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
 
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+
         PersistentDataContainer pdc = meta.getPersistentDataContainer();
         NamespacedKey maxKey = new NamespacedKey(plugin, "max_durability");
         NamespacedKey curKey = new NamespacedKey(plugin, "durability");
         Integer max = pdc.get(maxKey, PersistentDataType.INTEGER);
         Integer cur = pdc.get(curKey, PersistentDataType.INTEGER);
         if (max != null && cur != null) {
+            item.setItemMeta(meta);
             return; // already initialised
         }
 
         ToolMaterial material = ToolMaterial.fromMaterial(item.getType());
-        if (material == null) return;
+        if (material == null) {
+            item.setItemMeta(meta);
+            return;
+        }
         int value = material.getMaxDurability();
         pdc.set(maxKey, PersistentDataType.INTEGER, value);
         pdc.set(curKey, PersistentDataType.INTEGER, value);


### PR DESCRIPTION
## Summary
- hide attack damage/speed lines on stone and diamond pickaxe icons in the mine menu
- hide vanilla attribute lines on custom tools during creation and initialization
- redesign sell menu with central emerald button and black glass fillers

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_689d8fa6ade4832aa5652dcae5b9cfdd