### PR TITLE
Add console debug logs for custom tool durability

### DIFF
--- a/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/CustomTool.java
@@ -241,6 +241,26 @@ public final class CustomTool {
         return cur <= 0;
     }
 
+    /**
+     * Returns the current and maximum durability stored on the item.
+     * Primarily used for debugging purposes.
+     *
+     * @return array of [current, max] durability or {@code null} if not present
+     */
+    public static int[] getDurability(ItemStack item, Plugin plugin) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return null;
+
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        NamespacedKey maxKey = new NamespacedKey(plugin, "max_durability");
+        NamespacedKey curKey = new NamespacedKey(plugin, "durability");
+
+        Integer max = pdc.get(maxKey, PersistentDataType.INTEGER);
+        Integer cur = pdc.get(curKey, PersistentDataType.INTEGER);
+        if (max == null || cur == null) return null;
+        return new int[] { cur, max };
+    }
+
     public static int getDuplicateLevel(ItemStack item, Plugin plugin) {
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return 0;

--- a/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.maks.mineSystemPlugin.MineSystemPlugin;
 
@@ -52,6 +53,14 @@ public class ToolListener implements Listener {
             if (wasCancelled) {
                 plugin.getLogger().info("[ToolListener] Event was already cancelled before processing");
             }
+            plugin.getLogger().info("[ToolListener] pluginTool=" + pluginTool + ", tool=" + tool.getType());
+            ItemMeta meta = tool.getItemMeta();
+            if (meta != null) {
+                PersistentDataContainer pdc = meta.getPersistentDataContainer();
+                plugin.getLogger().info(
+                    "[ToolListener] hasCustomToolKey=" + pdc.has(toolKey, PersistentDataType.BYTE));
+                plugin.getLogger().info("[ToolListener] canDestroy=" + meta.getCanDestroy());
+            }
         }
 
         // restrict breaking inside spheres unless allowed
@@ -87,7 +96,28 @@ public class ToolListener implements Listener {
         // durability handling
         CustomTool.ensureDurability(tool, plugin);
 
+        if (debug) {
+            int[] before = CustomTool.getDurability(tool, plugin);
+            if (before != null) {
+                plugin.getLogger().info(
+                    "[ToolListener] Durability before hit: " + before[0] + "/" + before[1]);
+            } else {
+                plugin.getLogger().info("[ToolListener] Durability data missing before hit");
+            }
+        }
+
         boolean broken = CustomTool.damage(tool, plugin);
+
+        if (debug) {
+            int[] after = CustomTool.getDurability(tool, plugin);
+            if (after != null) {
+                plugin.getLogger().info(
+                    "[ToolListener] Durability after hit: " + after[0] + "/" + after[1]);
+            } else {
+                plugin.getLogger().info("[ToolListener] Durability data missing after hit");
+            }
+            plugin.getLogger().info("[ToolListener] Broken after hit: " + broken);
+        }
         if (broken) {
             player.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
         } else {


### PR DESCRIPTION
## Summary
- log custom tool detection details and durability changes when debug mode is enabled
- expose `getDurability` helper for retrieving stored durability values

## Testing
- `mvn -q -e -ntp test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e2938200c832a9b1a374831872a20