### PR TITLE
Disable debug logging by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Toggle various debug logs:
 ```yaml
 debug:
   toolListener: false
+  sphereManager: false
 ```
 
 

--- a/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
+++ b/src/main/java/org/maks/mineSystemPlugin/sphere/SphereManager.java
@@ -145,8 +145,9 @@ public class SphereManager {
         this.stamina = stamina;
         this.sphereRepository = sphereRepository;
         this.maxSpheres = 20;
+        // Debug logging can be enabled via configuration. Default is off.
         this.debug = plugin instanceof MineSystemPlugin mine
-                && mine.getConfig().getBoolean("debug.toolListener", false);
+                && mine.getConfig().getBoolean("debug.sphereManager", false);
     }
 
     /**

--- a/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
+++ b/src/main/java/org/maks/mineSystemPlugin/tool/ToolListener.java
@@ -46,9 +46,8 @@ public class ToolListener implements Listener {
 
     public ToolListener(MineSystemPlugin plugin) {
         this.plugin = plugin;
-        // Always enable debug output so durability problems can be traced even if
-        // the configuration flag is missing or set incorrectly.
-        this.debug = true;
+        // Debug output can be toggled through the configuration. Default is off.
+        this.debug = plugin.getConfig().getBoolean("debug.toolListener", false);
         this.toolKey = new NamespacedKey(plugin, "custom_tool");
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,3 +34,4 @@ sell-prices:
 
 debug:
   toolListener: false
+  sphereManager: false


### PR DESCRIPTION
## Summary
- Respect config flag for ToolListener debug output
- Add separate SphereManager debug flag
- Document and configure debug flags as disabled by default

## Testing
- ⚠️ `mvn -q -DskipTests package` *(network is unreachable for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689ed27885cc832abc4c11a856e729d3